### PR TITLE
Freebsd-support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,10 @@ on:
         description: 'Tests on Android (true or false)'
         required: true
         default: true
+      tests_on_freebsd:
+        description: 'Tests on FreeBSD (true or false)'
+        required: true
+        default: true
 
 jobs:
   tests_on_ubuntu:
@@ -271,3 +275,25 @@ jobs:
           arch: x86_64
           emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim
           script: ./test/android/run_tests.sh
+          
+  tests_on_freebsd:
+    name: Tests on FreeBSD
+    if: github.event.inputs.tests_on_freebsd == 'true' || github.event.inputs.tests_on_freebsd == ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test on freebsd
+        uses: cross-platform-actions/action@v0.32.0
+        with:
+          operating_system: freebsd
+          version: '15.0'
+          run: |
+            ls
+            sudo pkg install -y gmake
+            cd test && gmake relro_pie_tests
+            uname -a
+            echo $SHELL
+            pwd
+            ls -lah
+            whoami
+            env | sort

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -284,8 +284,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - { name: freebsd, version: '12.4' }
           - { name: freebsd, version: '15.0' }
           - { name: netbsd,  version: '10.1' }
+        architecture:
+          - x86-64
+          - arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -295,6 +299,7 @@ jobs:
         with:
           operating_system: ${{ matrix.os.name }}
           version: ${{ matrix.os.version }}
+          architecture: ${{ matrix.architecture }}
           run: |
             OS=$(uname -s)
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -300,6 +300,7 @@ jobs:
           operating_system: ${{ matrix.os.name }}
           version: ${{ matrix.os.version }}
           architecture: ${{ matrix.architecture }}
+          shell: sh
           run: |
             OS=$(uname -s)
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -307,14 +307,9 @@ jobs:
 
             if [ "$OS" = "FreeBSD" ]; then
               if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
-                # fetch https://download.freebsd.org/ports/ports/ports.tar.xz
-                # sudo tar -xJf ports.tar.xz -C /usr
-                # cd /usr/ports/devel/gmake
-                # sudo make install clean
-                fetch -o gmake.tar.gz https://ports.freebsd.org/cgi/ports.cgi/devel/gmake.tar.gz
-                sudo tar xf gmake.tar.gz
-                cd gmake
-                make -DBATCH install clean
+                ARCH=$(uname -m)
+                fetch https://pkg.freebsd.org/FreeBSD:12:${ARCH}/latest/All/gmake-4.4.1.pkg
+                sudo pkg add gmake-4.4.1.pkg
               else
                 sudo pkg install -y gmake
               fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -305,10 +305,12 @@ jobs:
             set -exuo pipefail
             OS=$(uname -s)
 
+            which make
+
             if [ "$OS" = "FreeBSD" ]; then
               if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
                 fetch https://download.freebsd.org/ports/ports/ports.tar.xz
-                sudo tar xf ports.tar.gz -C /usr
+                sudo tar -xJf ports.tar.xz -C /usr
                 cd /usr/ports/devel/gmake
                 sudo make install clean
               else

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -306,13 +306,7 @@ jobs:
             OS=$(uname -s)
 
             if [ "$OS" = "FreeBSD" ]; then
-              if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
-                ARCH=$(uname -m)
-                fetch https://pkg.freebsd.org/FreeBSD:12:${ARCH}/latest/All/gmake-4.4.1.pkg
-                sudo pkg add gmake-4.4.1.pkg
-              else
-                sudo pkg install -y gmake
-              fi
+                env IGNORE_OSVERSION=yes sudo pkg install -y gmake
             elif [ "$OS" = "NetBSD" ]; then
               sudo pkgin -y install gmake
             fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -305,18 +305,21 @@ jobs:
             set -exuo pipefail
             OS=$(uname -s)
 
-            # if [ "$OS" = "FreeBSD" ]; then
-            #   if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
-            #     fetch https://download.freebsd.org/ports/ports/ports.tar.xz
-            #     sudo tar -xJf ports.tar.xz -C /usr
-            #     cd /usr/ports/devel/gmake
-            #     sudo make install clean
-            #   else
-            #     sudo pkg install -y gmake
-            #   fi
-            # elif [ "$OS" = "NetBSD" ]; then
-            #   sudo pkgin -y install gmake
-            # fi
+            if [ "$OS" = "FreeBSD" ]; then
+              if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
+                # fetch https://download.freebsd.org/ports/ports/ports.tar.xz
+                # sudo tar -xJf ports.tar.xz -C /usr
+                # cd /usr/ports/devel/gmake
+                # sudo make install clean
+                fetch -o gmake.tar.gz https://ports.freebsd.org/cgi/ports.cgi/devel/gmake.tar.gz
+                sudo tar xf gmake.tar.gz
+                cd gmake
+                make -DBATCH install clean
+              else
+                sudo pkg install -y gmake
+              fi
+            elif [ "$OS" = "NetBSD" ]; then
+              sudo pkgin -y install gmake
+            fi
 
-            # cd test && gmake relro_pie_tests
-            cd test && make relro_pie_tests
+            cd test && gmake relro_pie_tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -305,19 +305,18 @@ jobs:
             set -exuo pipefail
             OS=$(uname -s)
 
-            which make
+            # if [ "$OS" = "FreeBSD" ]; then
+            #   if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
+            #     fetch https://download.freebsd.org/ports/ports/ports.tar.xz
+            #     sudo tar -xJf ports.tar.xz -C /usr
+            #     cd /usr/ports/devel/gmake
+            #     sudo make install clean
+            #   else
+            #     sudo pkg install -y gmake
+            #   fi
+            # elif [ "$OS" = "NetBSD" ]; then
+            #   sudo pkgin -y install gmake
+            # fi
 
-            if [ "$OS" = "FreeBSD" ]; then
-              if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
-                fetch https://download.freebsd.org/ports/ports/ports.tar.xz
-                sudo tar -xJf ports.tar.xz -C /usr
-                cd /usr/ports/devel/gmake
-                sudo make install clean
-              else
-                sudo pkg install -y gmake
-              fi
-            elif [ "$OS" = "NetBSD" ]; then
-              sudo pkgin -y install gmake
-            fi
-
-            cd test && gmake relro_pie_tests
+            # cd test && gmake relro_pie_tests
+            cd test && make relro_pie_tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -306,7 +306,17 @@ jobs:
             OS=$(uname -s)
 
             if [ "$OS" = "FreeBSD" ]; then
-                env IGNORE_OSVERSION=yes sudo pkg install -y gmake
+              if pkg install -y gmake 2>/dev/null; then
+                :
+              else
+                fetch https://ftp.gnu.org/gnu/make/make-4.4.1.tar.gz
+                tar xzf make-4.4.1.tar.gz
+                cd make-4.4.1
+                ./configure
+                sh build.sh
+                sudo cp make /usr/local/bin/gmake
+                cd ..
+              fi
             elif [ "$OS" = "NetBSD" ]; then
               sudo pkgin -y install gmake
             fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -307,7 +307,7 @@ jobs:
 
             if [ "$OS" = "FreeBSD" ]; then
               if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
-                fetch https://cgit.freebsd.org/ports/snapshot/ports.tar.gz
+                fetch https://download.freebsd.org/ports/ports/ports.tar.xz
                 sudo tar xf ports.tar.gz -C /usr
                 cd /usr/ports/devel/gmake
                 sudo make install clean

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -302,10 +302,18 @@ jobs:
           architecture: ${{ matrix.architecture }}
           shell: sh
           run: |
+            set -exuo pipefail
             OS=$(uname -s)
 
             if [ "$OS" = "FreeBSD" ]; then
-              sudo pkg install -y gmake
+              if [ "$(uname -r | cut -d. -f1)" = "12" ]; then
+                fetch https://cgit.freebsd.org/ports/snapshot/ports.tar.gz
+                sudo tar xf ports.tar.gz -C /usr
+                cd /usr/ports/devel/gmake
+                sudo make install clean
+              else
+                sudo pkg install -y gmake
+              fi
             elif [ "$OS" = "NetBSD" ]; then
               sudo pkgin -y install gmake
             fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,8 +29,8 @@ on:
         description: 'Tests on Android (true or false)'
         required: true
         default: true
-      tests_on_freebsd:
-        description: 'Tests on FreeBSD (true or false)'
+      tests_on_bsd:
+        description: 'Tests on BSD (FreeBSD and NetBSD)'
         required: true
         default: true
 
@@ -276,17 +276,32 @@ jobs:
           emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim
           script: ./test/android/run_tests.sh
 
-  tests_on_freebsd:
-    name: Tests on FreeBSD
-    if: github.event.inputs.tests_on_freebsd == 'true' || github.event.inputs.tests_on_freebsd == ''
+  tests_on_bsd:
+    name: Tests on BSD
+    if: github.event.inputs.tests_on_bsd == 'true' || github.event.inputs.tests_on_bsd == ''
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - { name: freebsd, version: '15.0' }
+          - { name: netbsd,  version: '10.1' }
+
     steps:
       - uses: actions/checkout@v4
-      - name: Test on freebsd
+
+      - name: Test on BSD
         uses: cross-platform-actions/action@v0.32.0
         with:
-          operating_system: freebsd
-          version: '15.0'
+          operating_system: ${{ matrix.os.name }}
+          version: ${{ matrix.os.version }}
           run: |
-            sudo pkg install -y gmake
+            OS=$(uname -s)
+
+            if [ "$OS" = "FreeBSD" ]; then
+              sudo pkg install -y gmake
+            elif [ "$OS" = "NetBSD" ]; then
+              sudo pkgin -y install gmake
+            fi
+
             cd test && gmake relro_pie_tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -275,7 +275,7 @@ jobs:
           arch: x86_64
           emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim
           script: ./test/android/run_tests.sh
-          
+
   tests_on_freebsd:
     name: Tests on FreeBSD
     if: github.event.inputs.tests_on_freebsd == 'true' || github.event.inputs.tests_on_freebsd == ''
@@ -288,12 +288,5 @@ jobs:
           operating_system: freebsd
           version: '15.0'
           run: |
-            ls
             sudo pkg install -y gmake
             cd test && gmake relro_pie_tests
-            uname -a
-            echo $SHELL
-            pwd
-            ls -lah
-            whoami
-            env | sort

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -321,6 +321,6 @@ jobs:
             elif [ "$OS" = "NetBSD" ]; then
               sudo pkgin -y install gmake
             elif [ "$OS" = "OpenBSD" ]; then
-              pkg_add -I gmake
+              sudo pkg_add -I gmake
             fi
             cd test && gmake relro_pie_tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,246 +35,246 @@ on:
         default: true
 
 jobs:
-  # tests_on_ubuntu:
-  #   name: Tests on Ubuntu (x86_64 and i686)
-  #   if: github.event.inputs.tests_on_ubuntu == 'true' || github.event.inputs.tests_on_ubuntu == ''
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       optimization: ["", "-O3"]
-  #       sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       working-directory: test
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Install packages
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y gcc-multilib libc6-dbg valgrind
-  #       sudo dpkg --add-architecture i386
-  #       sudo apt update
-  #       sudo apt install -y libc6-dbg:i386 libgcc-s1:i386
-  #   - name: set OPT_CLFAGS
-  #     run: |
-  #       echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
-  #   - name: x86_64
-  #     run: |
-  #       make relro_pie_tests
-  #   - name: i686
-  #     run: |
-  #       make relro_pie_m32_tests
-  #   - name: x86_64 on valgrind
-  #     if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
-  #     run: |
-  #       make relro_pie_tests_on_valgrind
-  #   - name: uclibc x86_64
-  #     if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
-  #     run: |
-  #       ./uclibc-test.sh x86_64
-  #   - name: uclibc i686
-  #     if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
-  #     run: |
-  #       ./uclibc-test.sh i686
+  tests_on_ubuntu:
+    name: Tests on Ubuntu (x86_64 and i686)
+    if: github.event.inputs.tests_on_ubuntu == 'true' || github.event.inputs.tests_on_ubuntu == ''
+    strategy:
+      fail-fast: false
+      matrix:
+        optimization: ["", "-O3"]
+        sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: test
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install packages
+      run: |
+        sudo apt update
+        sudo apt install -y gcc-multilib libc6-dbg valgrind
+        sudo dpkg --add-architecture i386
+        sudo apt update
+        sudo apt install -y libc6-dbg:i386 libgcc-s1:i386
+    - name: set OPT_CLFAGS
+      run: |
+        echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
+    - name: x86_64
+      run: |
+        make relro_pie_tests
+    - name: i686
+      run: |
+        make relro_pie_m32_tests
+    - name: x86_64 on valgrind
+      if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
+      run: |
+        make relro_pie_tests_on_valgrind
+    - name: uclibc x86_64
+      if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
+      run: |
+        ./uclibc-test.sh x86_64
+    - name: uclibc i686
+      if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
+      run: |
+        ./uclibc-test.sh i686
 
-  # tests_on_qemu:
-  #   name: Tests on Qemu (arm, armhf, arm64, ppc, ppc64le, riscv64, s390x and loongarch64)
-  #   if: github.event.inputs.tests_on_qemu == 'true' || github.event.inputs.tests_on_qemu == ''
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       optimization: ["", "-O2", "-O3"]
-  #       # TODO: Sanitizer fails in armhf and aarch64
-  #       # sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       working-directory: test
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Install packages
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y qemu-user gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-powerpc-linux-gnu gcc-powerpc64le-linux-gnu gcc-riscv64-linux-gnu gcc-s390x-linux-gnu gcc-14-loongarch64-linux-gnu libc6-dev-armhf-cross libc6-dev-ppc64el-cross libc6-dev-powerpc-cross libc6-dev-armel-cross libc6-dev-arm64-cross libc6-dev-s390x-cross libc6-dev-loong64-cross
-  #   - name: Set OPT_CLFAGS
-  #     run: |
-  #       echo OPT_CFLAGS="${{ matrix.optimization }}" >> $GITHUB_ENV
-  #     # TODO: Sanitizer fails in armhf and aarch64
-  #     # echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
-  #   - name: arm-linux-gnueabi
-  #     env:
-  #       OPT_CFLAGS: "-latomic"
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabi
-  #   - name: arm-linux-gnueabihf
-  #     env:
-  #       # TODO: detect_leaks=0 because it fails to create the ptrace thread
-  #       LSAN_OPTIONS: "verbosity=1:log_threads=1:detect_leaks=0"
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabihf
-  #   - name: aarch64-linux-gnu
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=aarch64-linux-gnu
-  #   - name: powerpc-linux-gnu
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=powerpc-linux-gnu QEMU_ARCH=ppc
-  #   - name: powerpc64le-linux-gnu
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=powerpc64le-linux-gnu QEMU_ARCH=ppc64le
-  #   - name: riscv64-linux-gnu
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
-  #   - name: s390x-linux-gnu
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=s390x-linux-gnu QEMU_ARCH=s390x
-  #   - name: loongarch64-linux-gnu
-  #     run: |
-  #       make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=14
+  tests_on_qemu:
+    name: Tests on Qemu (arm, armhf, arm64, ppc, ppc64le, riscv64, s390x and loongarch64)
+    if: github.event.inputs.tests_on_qemu == 'true' || github.event.inputs.tests_on_qemu == ''
+    strategy:
+      fail-fast: false
+      matrix:
+        optimization: ["", "-O2", "-O3"]
+        # TODO: Sanitizer fails in armhf and aarch64
+        # sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: test
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install packages
+      run: |
+        sudo apt update
+        sudo apt install -y qemu-user gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-powerpc-linux-gnu gcc-powerpc64le-linux-gnu gcc-riscv64-linux-gnu gcc-s390x-linux-gnu gcc-14-loongarch64-linux-gnu libc6-dev-armhf-cross libc6-dev-ppc64el-cross libc6-dev-powerpc-cross libc6-dev-armel-cross libc6-dev-arm64-cross libc6-dev-s390x-cross libc6-dev-loong64-cross
+    - name: Set OPT_CLFAGS
+      run: |
+        echo OPT_CFLAGS="${{ matrix.optimization }}" >> $GITHUB_ENV
+      # TODO: Sanitizer fails in armhf and aarch64
+      # echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
+    - name: arm-linux-gnueabi
+      env:
+        OPT_CFLAGS: "-latomic"
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabi
+    - name: arm-linux-gnueabihf
+      env:
+        # TODO: detect_leaks=0 because it fails to create the ptrace thread
+        LSAN_OPTIONS: "verbosity=1:log_threads=1:detect_leaks=0"
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabihf
+    - name: aarch64-linux-gnu
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=aarch64-linux-gnu
+    - name: powerpc-linux-gnu
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=powerpc-linux-gnu QEMU_ARCH=ppc
+    - name: powerpc64le-linux-gnu
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=powerpc64le-linux-gnu QEMU_ARCH=ppc64le
+    - name: riscv64-linux-gnu
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
+    - name: s390x-linux-gnu
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=s390x-linux-gnu QEMU_ARCH=s390x
+    - name: loongarch64-linux-gnu
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=14
 
-  # tests_on_macos:
-  #   name: Tests on macOS
-  #   if: github.event.inputs.tests_on_macos == 'true' || github.event.inputs.tests_on_macos == ''
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [macos-14, macos-15, macos-15-intel]
-  #       optimization: ["", "-O3"]
-  #       sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
-  #   runs-on: ${{ matrix.os }}
-  #   defaults:
-  #     run:
-  #       working-directory: test
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: make
-  #     run: |
-  #       make clean libtest.so testprog
-  #   - name: otool -l testprog
-  #     run: |
-  #       otool -l testprog
-  #   - name: otool -l libtest.so
-  #     run: |
-  #       otool -l libtest.so
-  #   - name: dyldinfo
-  #     run: |
-  #       xcrun dyldinfo 2>&1 | tee dyldinfo-help.txt
-  #       for arg in $(awk '/^\t-/ {print $1}' dyldinfo-help.txt); do echo "======== $arg ========"; xcrun dyldinfo $arg libtest.so; done
-  #   - name: dyld_info
-  #     run: |
-  #       for arg in -segments -dependents -inits -exports -imports -objc -fixups -fixup_chains -fixup_chain_details -symbolic_fixups; do echo "======== $arg ========"; xcrun dyld_info $arg libtest.so; done; true
-  #   - name: set OPT_CLFAGS
-  #     run: |
-  #       echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
-  #   - name: Tests
-  #     run: |
-  #       make run_tests
+  tests_on_macos:
+    name: Tests on macOS
+    if: github.event.inputs.tests_on_macos == 'true' || github.event.inputs.tests_on_macos == ''
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15, macos-15-intel]
+        optimization: ["", "-O3"]
+        sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: test
+    steps:
+    - uses: actions/checkout@v4
+    - name: make
+      run: |
+        make clean libtest.so testprog
+    - name: otool -l testprog
+      run: |
+        otool -l testprog
+    - name: otool -l libtest.so
+      run: |
+        otool -l libtest.so
+    - name: dyldinfo
+      run: |
+        xcrun dyldinfo 2>&1 | tee dyldinfo-help.txt
+        for arg in $(awk '/^\t-/ {print $1}' dyldinfo-help.txt); do echo "======== $arg ========"; xcrun dyldinfo $arg libtest.so; done
+    - name: dyld_info
+      run: |
+        for arg in -segments -dependents -inits -exports -imports -objc -fixups -fixup_chains -fixup_chain_details -symbolic_fixups; do echo "======== $arg ========"; xcrun dyld_info $arg libtest.so; done; true
+    - name: set OPT_CLFAGS
+      run: |
+        echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
+    - name: Tests
+      run: |
+        make run_tests
 
-  # tests_on_windows:
-  #   name: Tests on Windows (x86 and x64)
-  #   if: github.event.inputs.tests_on_windows == 'true' || github.event.inputs.tests_on_windows == ''
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [2019, 2022, 2025]
-  #       architecture: [x86, x64]
-  #       options: [
-  #         { dll: "/LD /MD", exe: "/MD" },
-  #         { dll: "/LD /MD /O2", exe: "/MD /O2" },
-  #         { dll: "/LDd /MDd", exe: "/MDd" },
-  #         { dll: "/LDd /MDd /Z7 /fsanitize=address", exe: "/MDd /Z7 /fsanitize=address" }
-  #       ]
-  #   runs-on: windows-${{ matrix.os }}
-  #   defaults:
-  #     run:
-  #       shell: cmd
-  #       working-directory: test
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: ilammy/msvc-dev-cmd@v1
-  #   - name: Test
-  #     run: |
-  #       run-test.bat ${{ matrix.os }} ${{ matrix.architecture }} "${{ matrix.options.dll }}" "${{ matrix.options.exe }}"
+  tests_on_windows:
+    name: Tests on Windows (x86 and x64)
+    if: github.event.inputs.tests_on_windows == 'true' || github.event.inputs.tests_on_windows == ''
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [2019, 2022, 2025]
+        architecture: [x86, x64]
+        options: [
+          { dll: "/LD /MD", exe: "/MD" },
+          { dll: "/LD /MD /O2", exe: "/MD /O2" },
+          { dll: "/LDd /MDd", exe: "/MDd" },
+          { dll: "/LDd /MDd /Z7 /fsanitize=address", exe: "/MDd /Z7 /fsanitize=address" }
+        ]
+    runs-on: windows-${{ matrix.os }}
+    defaults:
+      run:
+        shell: cmd
+        working-directory: test
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Test
+      run: |
+        run-test.bat ${{ matrix.os }} ${{ matrix.architecture }} "${{ matrix.options.dll }}" "${{ matrix.options.exe }}"
 
-  # tests_on_msys2:
-  #   name: Tests on Windows MSYS2
-  #   if: github.event.inputs.tests_on_msys2 == 'true' || github.event.inputs.tests_on_msys2 == ''
-  #   runs-on: windows-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - { sys: mingw64, env: x86_64 }
-  #         - { sys: mingw32, env: i686 }
-  #         - { sys: ucrt64,  env: ucrt-x86_64 }
-  #         - { sys: clang64, env: clang-x86_64 }
-  #         # TODO: https://github.com/msys2/setup-msys2/blob/6df6372aff24e336858c5d4fb306df20b87ea877/examples/cmake.yml#L22
-  #         # - { sys: clangarm64, runs-on: windows-11-arm }
+  tests_on_msys2:
+    name: Tests on Windows MSYS2
+    if: github.event.inputs.tests_on_msys2 == 'true' || github.event.inputs.tests_on_msys2 == ''
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+          - { sys: ucrt64,  env: ucrt-x86_64 }
+          - { sys: clang64, env: clang-x86_64 }
+          # TODO: https://github.com/msys2/setup-msys2/blob/6df6372aff24e336858c5d4fb306df20b87ea877/examples/cmake.yml#L22
+          # - { sys: clangarm64, runs-on: windows-11-arm }
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Setup MSYS2
-  #       uses: msys2/setup-msys2@v2.30.0
-  #       with:
-  #         msystem: ${{ matrix.sys }}
-  #         update: true
-  #         install: >
-  #           mingw-w64-${{ matrix.env }}-gcc
-  #           make
-  #     - name: Run Tests
-  #       shell: msys2 {0}
-  #       working-directory: test
-  #       run: |
-  #         make run_tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2.30.0
+        with:
+          msystem: ${{ matrix.sys }}
+          update: true
+          install: >
+            mingw-w64-${{ matrix.env }}-gcc
+            make
+      - name: Run Tests
+        shell: msys2 {0}
+        working-directory: test
+        run: |
+          make run_tests
 
-  # tests_on_android:
-  #   name: Tests on Android
-  #   if: github.event.inputs.tests_on_android == 'true' || github.event.inputs.tests_on_android == ''
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out the repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+  tests_on_android:
+    name: Tests on Android
+    if: github.event.inputs.tests_on_android == 'true' || github.event.inputs.tests_on_android == ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-  #     - name: Setup Android SDK
-  #       uses: android-actions/setup-android@v3
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
-  #     - name: Install Android NDK
-  #       env:
-  #         ANDROID_NDK_VERSION: "26.1.10909125"
-  #       run: |
-  #         sdkmanager "ndk;${ANDROID_NDK_VERSION}"
-  #         NDK_PATH="$ANDROID_SDK_ROOT/ndk/${ANDROID_NDK_VERSION}"
-  #         echo "ANDROID_NDK_HOME=$NDK_PATH" >> $GITHUB_ENV
-  #         echo "ANDROID_NDK=$NDK_PATH" >> $GITHUB_ENV
-  #         echo "$NDK_PATH" >> $GITHUB_PATH
+      - name: Install Android NDK
+        env:
+          ANDROID_NDK_VERSION: "26.1.10909125"
+        run: |
+          sdkmanager "ndk;${ANDROID_NDK_VERSION}"
+          NDK_PATH="$ANDROID_SDK_ROOT/ndk/${ANDROID_NDK_VERSION}"
+          echo "ANDROID_NDK_HOME=$NDK_PATH" >> $GITHUB_ENV
+          echo "ANDROID_NDK=$NDK_PATH" >> $GITHUB_ENV
+          echo "$NDK_PATH" >> $GITHUB_PATH
 
-  #     - name: Enable KVM
-  #       run: |
-  #         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-  #         sudo udevadm control --reload-rules
-  #         sudo udevadm trigger --name-match=kvm
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
-  #     - name: Build native tests with ndk-build
-  #       working-directory: ./test/android
-  #       run: |
-  #         "$ANDROID_NDK_HOME/ndk-build" NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk NDK_APPLICATION_MK=jni/Application.mk
+      - name: Build native tests with ndk-build
+        working-directory: ./test/android
+        run: |
+          "$ANDROID_NDK_HOME/ndk-build" NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk NDK_APPLICATION_MK=jni/Application.mk
 
-  #     - name: Run Tests on Android Emulator
-  #       uses: reactivecircus/android-emulator-runner@v2
-  #       with:
-  #         api-level: 34
-  #         target: default
-  #         arch: x86_64
-  #         emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim
-  #         script: ./test/android/run_tests.sh
+      - name: Run Tests on Android Emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: default
+          arch: x86_64
+          emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim
+          script: ./test/android/run_tests.sh
 
   tests_on_bsd:
     name: Tests on BSD
@@ -287,7 +287,7 @@ jobs:
           - { name: freebsd, version: '12.4' }
           - { name: freebsd, version: '15.0' }
           - { name: netbsd,  version: '10.1' }
-          - { name: openbsd, version: '7.6' }
+          # - { name: openbsd, version: '7.6' }
         architecture:
           - x86-64
           - arm64
@@ -320,7 +320,7 @@ jobs:
               fi
             elif [ "$OS" = "NetBSD" ]; then
               sudo pkgin -y install gmake
-            elif [ "$OS" = "OpenBSD" ]; then
-              sudo pkg_add -I gmake
+            # elif [ "$OS" = "OpenBSD" ]; then
+            #   sudo pkg_add -I gmake
             fi
             cd test && gmake relro_pie_tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,246 +35,246 @@ on:
         default: true
 
 jobs:
-  tests_on_ubuntu:
-    name: Tests on Ubuntu (x86_64 and i686)
-    if: github.event.inputs.tests_on_ubuntu == 'true' || github.event.inputs.tests_on_ubuntu == ''
-    strategy:
-      fail-fast: false
-      matrix:
-        optimization: ["", "-O3"]
-        sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: test
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install packages
-      run: |
-        sudo apt update
-        sudo apt install -y gcc-multilib libc6-dbg valgrind
-        sudo dpkg --add-architecture i386
-        sudo apt update
-        sudo apt install -y libc6-dbg:i386 libgcc-s1:i386
-    - name: set OPT_CLFAGS
-      run: |
-        echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
-    - name: x86_64
-      run: |
-        make relro_pie_tests
-    - name: i686
-      run: |
-        make relro_pie_m32_tests
-    - name: x86_64 on valgrind
-      if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
-      run: |
-        make relro_pie_tests_on_valgrind
-    - name: uclibc x86_64
-      if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
-      run: |
-        ./uclibc-test.sh x86_64
-    - name: uclibc i686
-      if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
-      run: |
-        ./uclibc-test.sh i686
+  # tests_on_ubuntu:
+  #   name: Tests on Ubuntu (x86_64 and i686)
+  #   if: github.event.inputs.tests_on_ubuntu == 'true' || github.event.inputs.tests_on_ubuntu == ''
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       optimization: ["", "-O3"]
+  #       sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       working-directory: test
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Install packages
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y gcc-multilib libc6-dbg valgrind
+  #       sudo dpkg --add-architecture i386
+  #       sudo apt update
+  #       sudo apt install -y libc6-dbg:i386 libgcc-s1:i386
+  #   - name: set OPT_CLFAGS
+  #     run: |
+  #       echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
+  #   - name: x86_64
+  #     run: |
+  #       make relro_pie_tests
+  #   - name: i686
+  #     run: |
+  #       make relro_pie_m32_tests
+  #   - name: x86_64 on valgrind
+  #     if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
+  #     run: |
+  #       make relro_pie_tests_on_valgrind
+  #   - name: uclibc x86_64
+  #     if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
+  #     run: |
+  #       ./uclibc-test.sh x86_64
+  #   - name: uclibc i686
+  #     if: ${{ matrix.sanitize == '' }} # Run without sanitizers only
+  #     run: |
+  #       ./uclibc-test.sh i686
 
-  tests_on_qemu:
-    name: Tests on Qemu (arm, armhf, arm64, ppc, ppc64le, riscv64, s390x and loongarch64)
-    if: github.event.inputs.tests_on_qemu == 'true' || github.event.inputs.tests_on_qemu == ''
-    strategy:
-      fail-fast: false
-      matrix:
-        optimization: ["", "-O2", "-O3"]
-        # TODO: Sanitizer fails in armhf and aarch64
-        # sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: test
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install packages
-      run: |
-        sudo apt update
-        sudo apt install -y qemu-user gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-powerpc-linux-gnu gcc-powerpc64le-linux-gnu gcc-riscv64-linux-gnu gcc-s390x-linux-gnu gcc-14-loongarch64-linux-gnu libc6-dev-armhf-cross libc6-dev-ppc64el-cross libc6-dev-powerpc-cross libc6-dev-armel-cross libc6-dev-arm64-cross libc6-dev-s390x-cross libc6-dev-loong64-cross
-    - name: Set OPT_CLFAGS
-      run: |
-        echo OPT_CFLAGS="${{ matrix.optimization }}" >> $GITHUB_ENV
-      # TODO: Sanitizer fails in armhf and aarch64
-      # echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
-    - name: arm-linux-gnueabi
-      env:
-        OPT_CFLAGS: "-latomic"
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabi
-    - name: arm-linux-gnueabihf
-      env:
-        # TODO: detect_leaks=0 because it fails to create the ptrace thread
-        LSAN_OPTIONS: "verbosity=1:log_threads=1:detect_leaks=0"
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabihf
-    - name: aarch64-linux-gnu
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=aarch64-linux-gnu
-    - name: powerpc-linux-gnu
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=powerpc-linux-gnu QEMU_ARCH=ppc
-    - name: powerpc64le-linux-gnu
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=powerpc64le-linux-gnu QEMU_ARCH=ppc64le
-    - name: riscv64-linux-gnu
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
-    - name: s390x-linux-gnu
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=s390x-linux-gnu QEMU_ARCH=s390x
-    - name: loongarch64-linux-gnu
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=14
+  # tests_on_qemu:
+  #   name: Tests on Qemu (arm, armhf, arm64, ppc, ppc64le, riscv64, s390x and loongarch64)
+  #   if: github.event.inputs.tests_on_qemu == 'true' || github.event.inputs.tests_on_qemu == ''
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       optimization: ["", "-O2", "-O3"]
+  #       # TODO: Sanitizer fails in armhf and aarch64
+  #       # sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       working-directory: test
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Install packages
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y qemu-user gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-powerpc-linux-gnu gcc-powerpc64le-linux-gnu gcc-riscv64-linux-gnu gcc-s390x-linux-gnu gcc-14-loongarch64-linux-gnu libc6-dev-armhf-cross libc6-dev-ppc64el-cross libc6-dev-powerpc-cross libc6-dev-armel-cross libc6-dev-arm64-cross libc6-dev-s390x-cross libc6-dev-loong64-cross
+  #   - name: Set OPT_CLFAGS
+  #     run: |
+  #       echo OPT_CFLAGS="${{ matrix.optimization }}" >> $GITHUB_ENV
+  #     # TODO: Sanitizer fails in armhf and aarch64
+  #     # echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
+  #   - name: arm-linux-gnueabi
+  #     env:
+  #       OPT_CFLAGS: "-latomic"
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabi
+  #   - name: arm-linux-gnueabihf
+  #     env:
+  #       # TODO: detect_leaks=0 because it fails to create the ptrace thread
+  #       LSAN_OPTIONS: "verbosity=1:log_threads=1:detect_leaks=0"
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabihf
+  #   - name: aarch64-linux-gnu
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=aarch64-linux-gnu
+  #   - name: powerpc-linux-gnu
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=powerpc-linux-gnu QEMU_ARCH=ppc
+  #   - name: powerpc64le-linux-gnu
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=powerpc64le-linux-gnu QEMU_ARCH=ppc64le
+  #   - name: riscv64-linux-gnu
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
+  #   - name: s390x-linux-gnu
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=s390x-linux-gnu QEMU_ARCH=s390x
+  #   - name: loongarch64-linux-gnu
+  #     run: |
+  #       make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=14
 
-  tests_on_macos:
-    name: Tests on macOS
-    if: github.event.inputs.tests_on_macos == 'true' || github.event.inputs.tests_on_macos == ''
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-14, macos-15, macos-15-intel]
-        optimization: ["", "-O3"]
-        sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: test
-    steps:
-    - uses: actions/checkout@v4
-    - name: make
-      run: |
-        make clean libtest.so testprog
-    - name: otool -l testprog
-      run: |
-        otool -l testprog
-    - name: otool -l libtest.so
-      run: |
-        otool -l libtest.so
-    - name: dyldinfo
-      run: |
-        xcrun dyldinfo 2>&1 | tee dyldinfo-help.txt
-        for arg in $(awk '/^\t-/ {print $1}' dyldinfo-help.txt); do echo "======== $arg ========"; xcrun dyldinfo $arg libtest.so; done
-    - name: dyld_info
-      run: |
-        for arg in -segments -dependents -inits -exports -imports -objc -fixups -fixup_chains -fixup_chain_details -symbolic_fixups; do echo "======== $arg ========"; xcrun dyld_info $arg libtest.so; done; true
-    - name: set OPT_CLFAGS
-      run: |
-        echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
-    - name: Tests
-      run: |
-        make run_tests
+  # tests_on_macos:
+  #   name: Tests on macOS
+  #   if: github.event.inputs.tests_on_macos == 'true' || github.event.inputs.tests_on_macos == ''
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [macos-14, macos-15, macos-15-intel]
+  #       optimization: ["", "-O3"]
+  #       sanitize: ["", "-g -fsanitize=address -fsanitize=undefined"]
+  #   runs-on: ${{ matrix.os }}
+  #   defaults:
+  #     run:
+  #       working-directory: test
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: make
+  #     run: |
+  #       make clean libtest.so testprog
+  #   - name: otool -l testprog
+  #     run: |
+  #       otool -l testprog
+  #   - name: otool -l libtest.so
+  #     run: |
+  #       otool -l libtest.so
+  #   - name: dyldinfo
+  #     run: |
+  #       xcrun dyldinfo 2>&1 | tee dyldinfo-help.txt
+  #       for arg in $(awk '/^\t-/ {print $1}' dyldinfo-help.txt); do echo "======== $arg ========"; xcrun dyldinfo $arg libtest.so; done
+  #   - name: dyld_info
+  #     run: |
+  #       for arg in -segments -dependents -inits -exports -imports -objc -fixups -fixup_chains -fixup_chain_details -symbolic_fixups; do echo "======== $arg ========"; xcrun dyld_info $arg libtest.so; done; true
+  #   - name: set OPT_CLFAGS
+  #     run: |
+  #       echo OPT_CFLAGS="${{ matrix.optimization }} ${{ matrix.sanitize }}" >> $GITHUB_ENV
+  #   - name: Tests
+  #     run: |
+  #       make run_tests
 
-  tests_on_windows:
-    name: Tests on Windows (x86 and x64)
-    if: github.event.inputs.tests_on_windows == 'true' || github.event.inputs.tests_on_windows == ''
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [2019, 2022, 2025]
-        architecture: [x86, x64]
-        options: [
-          { dll: "/LD /MD", exe: "/MD" },
-          { dll: "/LD /MD /O2", exe: "/MD /O2" },
-          { dll: "/LDd /MDd", exe: "/MDd" },
-          { dll: "/LDd /MDd /Z7 /fsanitize=address", exe: "/MDd /Z7 /fsanitize=address" }
-        ]
-    runs-on: windows-${{ matrix.os }}
-    defaults:
-      run:
-        shell: cmd
-        working-directory: test
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ilammy/msvc-dev-cmd@v1
-    - name: Test
-      run: |
-        run-test.bat ${{ matrix.os }} ${{ matrix.architecture }} "${{ matrix.options.dll }}" "${{ matrix.options.exe }}"
+  # tests_on_windows:
+  #   name: Tests on Windows (x86 and x64)
+  #   if: github.event.inputs.tests_on_windows == 'true' || github.event.inputs.tests_on_windows == ''
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [2019, 2022, 2025]
+  #       architecture: [x86, x64]
+  #       options: [
+  #         { dll: "/LD /MD", exe: "/MD" },
+  #         { dll: "/LD /MD /O2", exe: "/MD /O2" },
+  #         { dll: "/LDd /MDd", exe: "/MDd" },
+  #         { dll: "/LDd /MDd /Z7 /fsanitize=address", exe: "/MDd /Z7 /fsanitize=address" }
+  #       ]
+  #   runs-on: windows-${{ matrix.os }}
+  #   defaults:
+  #     run:
+  #       shell: cmd
+  #       working-directory: test
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - uses: ilammy/msvc-dev-cmd@v1
+  #   - name: Test
+  #     run: |
+  #       run-test.bat ${{ matrix.os }} ${{ matrix.architecture }} "${{ matrix.options.dll }}" "${{ matrix.options.exe }}"
 
-  tests_on_msys2:
-    name: Tests on Windows MSYS2
-    if: github.event.inputs.tests_on_msys2 == 'true' || github.event.inputs.tests_on_msys2 == ''
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
-          - { sys: ucrt64,  env: ucrt-x86_64 }
-          - { sys: clang64, env: clang-x86_64 }
-          # TODO: https://github.com/msys2/setup-msys2/blob/6df6372aff24e336858c5d4fb306df20b87ea877/examples/cmake.yml#L22
-          # - { sys: clangarm64, runs-on: windows-11-arm }
+  # tests_on_msys2:
+  #   name: Tests on Windows MSYS2
+  #   if: github.event.inputs.tests_on_msys2 == 'true' || github.event.inputs.tests_on_msys2 == ''
+  #   runs-on: windows-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - { sys: mingw64, env: x86_64 }
+  #         - { sys: mingw32, env: i686 }
+  #         - { sys: ucrt64,  env: ucrt-x86_64 }
+  #         - { sys: clang64, env: clang-x86_64 }
+  #         # TODO: https://github.com/msys2/setup-msys2/blob/6df6372aff24e336858c5d4fb306df20b87ea877/examples/cmake.yml#L22
+  #         # - { sys: clangarm64, runs-on: windows-11-arm }
 
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup MSYS2
-        uses: msys2/setup-msys2@v2.30.0
-        with:
-          msystem: ${{ matrix.sys }}
-          update: true
-          install: >
-            mingw-w64-${{ matrix.env }}-gcc
-            make
-      - name: Run Tests
-        shell: msys2 {0}
-        working-directory: test
-        run: |
-          make run_tests
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Setup MSYS2
+  #       uses: msys2/setup-msys2@v2.30.0
+  #       with:
+  #         msystem: ${{ matrix.sys }}
+  #         update: true
+  #         install: >
+  #           mingw-w64-${{ matrix.env }}-gcc
+  #           make
+  #     - name: Run Tests
+  #       shell: msys2 {0}
+  #       working-directory: test
+  #       run: |
+  #         make run_tests
 
-  tests_on_android:
-    name: Tests on Android
-    if: github.event.inputs.tests_on_android == 'true' || github.event.inputs.tests_on_android == ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  # tests_on_android:
+  #   name: Tests on Android
+  #   if: github.event.inputs.tests_on_android == 'true' || github.event.inputs.tests_on_android == ''
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out the repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+  #     - name: Setup Android SDK
+  #       uses: android-actions/setup-android@v3
 
-      - name: Install Android NDK
-        env:
-          ANDROID_NDK_VERSION: "26.1.10909125"
-        run: |
-          sdkmanager "ndk;${ANDROID_NDK_VERSION}"
-          NDK_PATH="$ANDROID_SDK_ROOT/ndk/${ANDROID_NDK_VERSION}"
-          echo "ANDROID_NDK_HOME=$NDK_PATH" >> $GITHUB_ENV
-          echo "ANDROID_NDK=$NDK_PATH" >> $GITHUB_ENV
-          echo "$NDK_PATH" >> $GITHUB_PATH
+  #     - name: Install Android NDK
+  #       env:
+  #         ANDROID_NDK_VERSION: "26.1.10909125"
+  #       run: |
+  #         sdkmanager "ndk;${ANDROID_NDK_VERSION}"
+  #         NDK_PATH="$ANDROID_SDK_ROOT/ndk/${ANDROID_NDK_VERSION}"
+  #         echo "ANDROID_NDK_HOME=$NDK_PATH" >> $GITHUB_ENV
+  #         echo "ANDROID_NDK=$NDK_PATH" >> $GITHUB_ENV
+  #         echo "$NDK_PATH" >> $GITHUB_PATH
 
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+  #     - name: Enable KVM
+  #       run: |
+  #         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+  #         sudo udevadm control --reload-rules
+  #         sudo udevadm trigger --name-match=kvm
 
-      - name: Build native tests with ndk-build
-        working-directory: ./test/android
-        run: |
-          "$ANDROID_NDK_HOME/ndk-build" NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk NDK_APPLICATION_MK=jni/Application.mk
+  #     - name: Build native tests with ndk-build
+  #       working-directory: ./test/android
+  #       run: |
+  #         "$ANDROID_NDK_HOME/ndk-build" NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk NDK_APPLICATION_MK=jni/Application.mk
 
-      - name: Run Tests on Android Emulator
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: default
-          arch: x86_64
-          emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim
-          script: ./test/android/run_tests.sh
+  #     - name: Run Tests on Android Emulator
+  #       uses: reactivecircus/android-emulator-runner@v2
+  #       with:
+  #         api-level: 34
+  #         target: default
+  #         arch: x86_64
+  #         emulator-options: -no-window -no-audio -no-snapshot -no-boot-anim
+  #         script: ./test/android/run_tests.sh
 
   tests_on_bsd:
     name: Tests on BSD

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -287,6 +287,7 @@ jobs:
           - { name: freebsd, version: '12.4' }
           - { name: freebsd, version: '15.0' }
           - { name: netbsd,  version: '10.1' }
+          - { name: openbsd, version: '7.6' }
         architecture:
           - x86-64
           - arm64
@@ -319,6 +320,7 @@ jobs:
               fi
             elif [ "$OS" = "NetBSD" ]; then
               sudo pkgin -y install gmake
+            elif [ "$OS" = "OpenBSD" ]; then
+              pkg_add -I gmake
             fi
-
             cd test && gmake relro_pie_tests

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -260,7 +260,8 @@ static int dl_iterate_cb(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
     Elf_Half idx = 0;
-
+    size_t real_base;
+    Elf_Dyn *dynamic;
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
         char* base = (char*)info->dlpi_addr + phdr->p_vaddr;
@@ -271,8 +272,9 @@ static int dl_iterate_cb(struct dl_phdr_info *info, size_t size, void *cb_data)
     if (idx == info->dlpi_phnum) {
         return 0;
     }
-    Elf_Addr real_base = info->dlpi_addr;
-    Elf_Dyn *dynamic = NULL;
+    real_base = info->dlpi_addr;
+    dynamic=NULL;
+    
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
 

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -356,8 +356,8 @@ static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_da
 }
 #endif
 
-#if defined __NetBSD__
-static int dl_iterate_exe_cb_netbsd(struct dl_phdr_info *info, size_t size, void *cb_data)
+#if defined __FreeBSD__ || defined __NetBSD__
+static int dl_iterate_exe_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
     Elf_Half idx;
@@ -880,11 +880,21 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     const Elf_Ehdr *ehdr;
     memset(&exe_data, 0, sizeof(exe_data));
     if (lmap->l_addr == 0) {
-        dl_iterate_phdr(dl_iterate_exe_cb_netbsd, &exe_data);
+        dl_iterate_phdr(dl_iterate_exe_cb_bsd, &exe_data);
         ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;
     } else {
         ehdr = (const Elf_Ehdr*)lmap->l_addr;
     }
+#elif defined __FreeBSD__                                                        
+      struct dl_iterate_data exe_data;                                             
+      const Elf_Ehdr *ehdr;                                                        
+      memset(&exe_data, 0, sizeof(exe_data));                                      
+      if (lmap->l_addr == 0) {                                                     
+          dl_iterate_phdr(dl_iterate_exe_cb_bsd, &exe_data);                       
+          ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;                            
+      } else {                                                                     
+          ehdr = (const Elf_Ehdr*)lmap->l_addr;                                    
+      }
 #else
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
 #endif

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -301,7 +301,7 @@ static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_da
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
     Elf_Half idx = 0;
 
-#if defined(__FreeBSD__)
+#if defined __FreeBSD__
     size_t real_base = info->dlpi_addr;
 #endif
 
@@ -321,14 +321,14 @@ static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_da
         return 0;
     }
 
-#if defined(__FreeBSD__)
+#if defined __FreeBSD__
     real_base = info->dlpi_addr;
 #endif
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
 
-#if defined(__FreeBSD__)
+#if defined __FreeBSD__
         if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
             real_base = info->dlpi_addr + phdr->p_vaddr;
         }
@@ -341,7 +341,7 @@ static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_da
 
     if (dynamic != NULL) {
 
-#if __FreeBSD__ >= 13
+#if defined __FreeBSD__ && __FreeBSD__ >= 13
         data->lmap.l_addr = (caddr_t)info->dlpi_addr;
         data->lmap.l_base = (caddr_t)real_base;
 #else
@@ -538,7 +538,7 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
 int plthook_open_by_address(plthook_t **plthook_out, void *address)
 {
 
-#if defined(__ANDROID__) || defined(__UCLIBC__)
+#if defined __ANDROID__ || defined __UCLIBC__
 
     struct dl_iterate_data data = {0,};
     data.addr = address;
@@ -553,7 +553,7 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
     return plthook_open_real(plthook_out, &data.lmap);
 
 
-#elif defined(__FreeBSD__) || defined(__NetBSD__)
+#elif defined __FreeBSD__ || defined __NetBSD__
 
     struct dl_iterate_data data = {0,};
     data.addr = address;
@@ -748,7 +748,7 @@ static void mem_prot_end(mem_prot_iter_t *iter)
 #elif defined __FreeBSD__ || defined __NetBSD__
 struct mem_prot_iter {
     struct kinfo_vmentry *kve;
-#if defined(__NetBSD__)
+#if defined __NetBSD__
     size_t idx;
     size_t num;
 #else
@@ -873,9 +873,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     dyn_addr_base = (const char*)lmap->l_addr;
 #endif
 #elif defined __FreeBSD__ || defined __sun || defined __NetBSD__
-#if __FreeBSD__ >= 13
-    const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_base;
-#elif defined __NetBSD__
+#if defined __NetBSD__
     struct dl_iterate_data exe_data;
     const Elf_Ehdr *ehdr;
     memset(&exe_data, 0, sizeof(exe_data));
@@ -885,16 +883,20 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     } else {
         ehdr = (const Elf_Ehdr*)lmap->l_addr;
     }
-#elif defined __FreeBSD__                                                        
-      struct dl_iterate_data exe_data;                                             
-      const Elf_Ehdr *ehdr;                                                        
-      memset(&exe_data, 0, sizeof(exe_data));                                      
-      if (lmap->l_addr == 0) {                                                     
-          dl_iterate_phdr(dl_iterate_exe_cb_bsd, &exe_data);                       
-          ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;                            
-      } else {                                                                     
-          ehdr = (const Elf_Ehdr*)lmap->l_addr;                                    
-      }
+#elif defined __FreeBSD__
+#if __FreeBSD__ < 13
+    struct dl_iterate_data exe_data;
+    const Elf_Ehdr *ehdr;
+    memset(&exe_data, 0, sizeof(exe_data));
+    if (lmap->l_addr == 0) {
+        dl_iterate_phdr(dl_iterate_exe_cb_bsd, &exe_data);
+        ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;
+    } else {
+        ehdr = (const Elf_Ehdr*)lmap->l_addr;
+    }
+#else
+    const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_base;
+#endif
 #else
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
 #endif
@@ -910,7 +912,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #error unsupported OS
 #endif
 
-    /* get .dynsym section */
+    /* Get .dynsym section */
     dyn = find_dyn_by_tag(lmap->l_ld, DT_SYMTAB);
     if (dyn == NULL) {
         set_errmsg("failed to find DT_SYMTAB");

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -365,10 +365,6 @@ static int dl_iterate_exe_cb_netbsd(struct dl_phdr_info *info, size_t size, void
     Elf_Dyn *dynamic = NULL;
 
     (void)size;
-    printf("dl_iterate_exe_cb_netbsd: name=%s, addr=%p\n",                                                                                                                          
-         info->dlpi_name ? info->dlpi_name : "(null)",                                                                                                                            
-         (void*)info->dlpi_addr); 
-
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
@@ -640,22 +636,9 @@ static int plthook_open_executable(plthook_t **plthook_out)
         return PLTHOOK_INTERNAL_ERROR;
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
-    #elif defined __FreeBSD__
-        return plthook_open_shared_library(plthook_out, NULL);
-
-    #elif defined __NetBSD__
-        struct dl_iterate_data data;
-        memset(&data, 0, sizeof(data));
-
-        dl_iterate_phdr(dl_iterate_exe_cb_netbsd, &data);
-
-        if (data.lmap.l_ld == NULL) {
-            set_errmsg("Could not find executable via dl_iterate_phdr");
-            return PLTHOOK_INTERNAL_ERROR;
-        }
-
-        return plthook_open_real(plthook_out, &data.lmap);
-    #endif
+    #elif defined __FreeBSD__ || defined __NetBSD__
+    return plthook_open_shared_library(plthook_out, NULL);
+#endif
 }
 
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
@@ -892,6 +875,16 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #elif defined __FreeBSD__ || defined __sun || defined __NetBSD__
 #if __FreeBSD__ >= 13
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_base;
+#elif defined __NetBSD__
+    struct dl_iterate_data exe_data;
+    const Elf_Ehdr *ehdr;
+    memset(&exe_data, 0, sizeof(exe_data));
+    if (lmap->l_addr == 0) {
+        dl_iterate_phdr(dl_iterate_exe_cb_netbsd, &exe_data);
+        ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;
+    } else {
+        ehdr = (const Elf_Ehdr*)lmap->l_addr;
+    }
 #else
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
 #endif

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -275,7 +275,7 @@ static int dl_iterate_cb(struct dl_phdr_info *info, size_t size, void *cb_data)
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
         if (phdr->p_type == PT_DYNAMIC) {
             #if __FreeBSD__ >= 13
-            data->lmap.l_addr = info->dlpi_addr;
+            data->lmap.l_addr = (caddr_t)info->dlpi_addr;
             data->lmap.l_base = (caddr_t)info->dlpi_addr;
             #else
             data->lmap.l_addr = info->dlpi_addr;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -60,6 +60,7 @@
 #endif
 #ifdef __NetBSD__
 #include <sys/types.h>
+#include <sys/sysctl.h>
 #include <util.h>
 #endif
 #include <elf.h>
@@ -334,7 +335,7 @@ static int dl_iterate_cb_freebsd(struct dl_phdr_info *info, size_t size, void *c
         data->lmap.l_addr = (caddr_t)info->dlpi_addr;
         data->lmap.l_base = (caddr_t)real_base;
 #else
-        data->lmap.l_addr = info->dlpi_addr;
+        data->lmap.l_addr = (caddr_t)info->dlpi_addr;
 #endif
 
         data->lmap.l_ld = dynamic;
@@ -709,7 +710,7 @@ static void mem_prot_end(mem_prot_iter_t *iter)
 struct mem_prot_iter {
     struct kinfo_vmentry *kve;
     int idx;
-    int num;
+    size_t num;
 };
 
 static int mem_prot_begin(mem_prot_iter_t *iter)

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -250,7 +250,7 @@ static void mem_prot_end(mem_prot_iter_t *iter);
 static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap);
 static int plthook_set_mem_prot(plthook_t *plthook);
 static int plthook_get_mem_prot(plthook_t *plthook, void *addr);
-#if defined __FreeBSD__ || defined __sun || defined __NetBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun
 static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
@@ -795,7 +795,7 @@ static void mem_prot_end(mem_prot_iter_t *iter)
         free(iter->kve);
     }
 }
-#elif defined(__sun)
+#elif defined __sun
 struct mem_prot_iter {
     FILE *fp;
     prmap_t maps[20];
@@ -872,7 +872,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #if defined __ANDROID__ || defined __UCLIBC__
     dyn_addr_base = (const char*)lmap->l_addr;
 #endif
-#elif defined __FreeBSD__ || defined __sun || defined __NetBSD__
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __sun
 #if defined __NetBSD__
     struct dl_iterate_data exe_data;
     const Elf_Ehdr *ehdr;
@@ -1053,7 +1053,7 @@ static int plthook_get_mem_prot(plthook_t *plthook, void *addr)
     return 0;
 }
 
-#if defined __FreeBSD__ || defined __sun || defined __NetBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun
 static int check_elf_header(const Elf_Ehdr *ehdr)
 {
     static const unsigned short s = 1;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -250,7 +250,7 @@ static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
 
-#if defined __ANDROID__ || defined __UCLIBC__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__
 struct dl_iterate_data {
     char* addr;
     struct link_map lmap;
@@ -274,7 +274,12 @@ static int dl_iterate_cb(struct dl_phdr_info *info, size_t size, void *cb_data)
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
         if (phdr->p_type == PT_DYNAMIC) {
+            #if __FreeBSD__ >= 13
             data->lmap.l_addr = info->dlpi_addr;
+            data->lmap.l_base = (caddr_t)info->dlpi_addr;
+            #else
+            data->lmap.l_addr = info->dlpi_addr;
+            #endif
             data->lmap.l_ld = (Elf_Dyn*)(info->dlpi_addr + phdr->p_vaddr);
             return 1;
         }
@@ -432,9 +437,7 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
 
 int plthook_open_by_address(plthook_t **plthook_out, void *address)
 {
-#if defined __FreeBSD__
-    return PLTHOOK_NOT_IMPLEMENTED;
-#elif defined __ANDROID__ || defined __UCLIBC__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__
     struct dl_iterate_data data = {0,};
     data.addr = address;
     dl_iterate_phdr(dl_iterate_cb, &data);

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -365,11 +365,10 @@ static int dl_iterate_exe_cb_netbsd(struct dl_phdr_info *info, size_t size, void
     Elf_Dyn *dynamic = NULL;
 
     (void)size;
+    printf("dl_iterate_exe_cb_netbsd: name=%s, addr=%p\n",                                                                                                                          
+         info->dlpi_name ? info->dlpi_name : "(null)",                                                                                                                            
+         (void*)info->dlpi_addr); 
 
-    /* main executable has empty name */
-    if (!(info->dlpi_name == NULL || info->dlpi_name[0] == '\0')) {
-        return 0;
-    }
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -271,19 +271,33 @@ static int dl_iterate_cb(struct dl_phdr_info *info, size_t size, void *cb_data)
     if (idx == info->dlpi_phnum) {
         return 0;
     }
+    Elf_Addr real_base = info->dlpi_addr;
+    Elf_Dyn *dynamic = NULL;
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+
+        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
+            real_base = info->dlpi_addr + phdr->p_vaddr;
+        }
+
         if (phdr->p_type == PT_DYNAMIC) {
-            #if __FreeBSD__ >= 13
-            data->lmap.l_addr = (caddr_t)info->dlpi_addr;
-            data->lmap.l_base = (caddr_t)info->dlpi_addr;
-            #else
-            data->lmap.l_addr = info->dlpi_addr;
-            #endif
-            data->lmap.l_ld = (Elf_Dyn*)(info->dlpi_addr + phdr->p_vaddr);
-            return 1;
+            dynamic = (Elf_Dyn*)(info->dlpi_addr + phdr->p_vaddr);
         }
     }
+
+    if (dynamic != NULL) {
+
+    #if __FreeBSD__ >= 13
+        data->lmap.l_addr = (caddr_t)info->dlpi_addr;
+        data->lmap.l_base = (caddr_t)real_base;  
+    #else
+        data->lmap.l_addr = info->dlpi_addr;
+    #endif
+
+        data->lmap.l_ld = dynamic;
+        return 1;
+    }
+
     return 0;
 }
 #endif

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -295,12 +295,18 @@ static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *c
 #endif
 
 #if defined __FreeBSD__ || defined __NetBSD__
-static int dl_iterate_cb_freebsd(struct dl_phdr_info *info, size_t size, void *cb_data)
+static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
+
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
     Elf_Half idx = 0;
-    size_t real_base;
+
+#if defined(__FreeBSD__)
+    size_t real_base = info->dlpi_addr;
+#endif
+
     Elf_Dyn *dynamic = NULL;
+    (void)size;
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
@@ -315,14 +321,18 @@ static int dl_iterate_cb_freebsd(struct dl_phdr_info *info, size_t size, void *c
         return 0;
     }
 
+#if defined(__FreeBSD__)
     real_base = info->dlpi_addr;
+#endif
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
 
+#if defined(__FreeBSD__)
         if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
             real_base = info->dlpi_addr + phdr->p_vaddr;
         }
+#endif
 
         if (phdr->p_type == PT_DYNAMIC) {
             dynamic = (Elf_Dyn*)(info->dlpi_addr + phdr->p_vaddr);
@@ -338,6 +348,43 @@ static int dl_iterate_cb_freebsd(struct dl_phdr_info *info, size_t size, void *c
         data->lmap.l_addr = (caddr_t)info->dlpi_addr;
 #endif
 
+        data->lmap.l_ld = dynamic;
+        return 1;
+    }
+
+    return 0;
+}
+#endif
+
+#if defined __NetBSD__
+static int dl_iterate_exe_cb_netbsd(struct dl_phdr_info *info, size_t size, void *cb_data)
+{
+    struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
+    Elf_Half idx;
+    size_t real_base = 0;
+    Elf_Dyn *dynamic = NULL;
+
+    (void)size;
+
+    /* main executable has empty name */
+    if (!(info->dlpi_name == NULL || info->dlpi_name[0] == '\0')) {
+        return 0;
+    }
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+
+        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
+            real_base = info->dlpi_addr + phdr->p_vaddr;
+        }
+
+        if (phdr->p_type == PT_DYNAMIC) {
+            dynamic = (Elf_Dyn*)(info->dlpi_addr + phdr->p_vaddr);
+        }
+    }
+
+    if (dynamic != NULL) {
+        data->lmap.l_addr = (caddr_t)real_base;
         data->lmap.l_ld = dynamic;
         return 1;
     }
@@ -516,7 +563,7 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
     struct dl_iterate_data data = {0,};
     data.addr = address;
 
-    dl_iterate_phdr(dl_iterate_cb_freebsd, &data);
+    dl_iterate_phdr(dl_iterate_cb_bsd, &data);
 
     if (data.lmap.l_ld == NULL) {
         set_errmsg("Could not find memory region containing address %p", address);
@@ -594,12 +641,22 @@ static int plthook_open_executable(plthook_t **plthook_out)
         return PLTHOOK_INTERNAL_ERROR;
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
-#elif defined __FreeBSD__ || defined __NetBSD__
-    return plthook_open_shared_library(plthook_out, NULL);
-#else
-    set_errmsg("Opening the main program is not supported on this platform.");
-    return PLTHOOK_NOT_IMPLEMENTED;
-#endif
+    #elif defined __FreeBSD__
+        return plthook_open_shared_library(plthook_out, NULL);
+
+    #elif defined __NetBSD__
+        struct dl_iterate_data data;
+        memset(&data, 0, sizeof(data));
+
+        dl_iterate_phdr(dl_iterate_exe_cb_netbsd, &data);
+
+        if (data.lmap.l_ld == NULL) {
+            set_errmsg("Could not find executable via dl_iterate_phdr");
+            return PLTHOOK_INTERNAL_ERROR;
+        }
+
+        return plthook_open_real(plthook_out, &data.lmap);
+    #endif
 }
 
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
@@ -709,12 +766,13 @@ static void mem_prot_end(mem_prot_iter_t *iter)
 #elif defined __FreeBSD__ || defined __NetBSD__
 struct mem_prot_iter {
     struct kinfo_vmentry *kve;
+#if defined(__NetBSD__)
+    size_t idx;
+    size_t num;
+#else
     int idx;
-    #if defined __NetBSD__
-      size_t num;
-    #else
-      int num;
-    #endif
+    int num;
+#endif
 };
 
 static int mem_prot_begin(mem_prot_iter_t *iter)

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -710,7 +710,11 @@ static void mem_prot_end(mem_prot_iter_t *iter)
 struct mem_prot_iter {
     struct kinfo_vmentry *kve;
     int idx;
-    size_t num;
+    #if defined __NetBSD__
+      size_t num;
+    #else
+      int num;
+    #endif
 };
 
 static int mem_prot_begin(mem_prot_iter_t *iter)

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -255,26 +255,63 @@ struct dl_iterate_data {
     char* addr;
     struct link_map lmap;
 };
-
-static int dl_iterate_cb(struct dl_phdr_info *info, size_t size, void *cb_data)
+#endif
+#if defined __ANDROID__ || defined __UCLIBC__
+static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
-    Elf_Half idx = 0;
-    size_t real_base;
-    Elf_Dyn *dynamic;
+    Elf_Half idx;
+
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        char* base = (char*)info->dlpi_addr + phdr->p_vaddr;
+        char *base = (char*)info->dlpi_addr + phdr->p_vaddr;
+
         if (base <= data->addr && data->addr < base + phdr->p_memsz) {
             break;
         }
     }
+
     if (idx == info->dlpi_phnum) {
         return 0;
     }
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+
+        if (phdr->p_type == PT_DYNAMIC) {
+            data->lmap.l_addr = info->dlpi_addr;
+            data->lmap.l_ld = (Elf_Dyn*)(info->dlpi_addr + phdr->p_vaddr);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+#endif
+
+#if defined __FreeBSD__
+static int dl_iterate_cb_freebsd(struct dl_phdr_info *info, size_t size, void *cb_data)
+{
+    struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
+    Elf_Half idx = 0;
+    size_t real_base;
+    Elf_Dyn *dynamic = NULL;
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        char* base = (char*)info->dlpi_addr + phdr->p_vaddr;
+
+        if (base <= data->addr && data->addr < base + phdr->p_memsz) {
+            break;
+        }
+    }
+
+    if (idx == info->dlpi_phnum) {
+        return 0;
+    }
+
     real_base = info->dlpi_addr;
-    dynamic=NULL;
-    
+
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
 
@@ -289,12 +326,12 @@ static int dl_iterate_cb(struct dl_phdr_info *info, size_t size, void *cb_data)
 
     if (dynamic != NULL) {
 
-    #if __FreeBSD__ >= 13
+#if __FreeBSD__ >= 13
         data->lmap.l_addr = (caddr_t)info->dlpi_addr;
-        data->lmap.l_base = (caddr_t)real_base;  
-    #else
+        data->lmap.l_base = (caddr_t)real_base;
+#else
         data->lmap.l_addr = info->dlpi_addr;
-    #endif
+#endif
 
         data->lmap.l_ld = dynamic;
         return 1;
@@ -453,16 +490,39 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
 
 int plthook_open_by_address(plthook_t **plthook_out, void *address)
 {
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__
+
+#if defined(__ANDROID__) || defined(__UCLIBC__)
+
     struct dl_iterate_data data = {0,};
     data.addr = address;
-    dl_iterate_phdr(dl_iterate_cb, &data);
+
+    dl_iterate_phdr(dl_iterate_cb_android, &data);
+
     if (data.lmap.l_ld == NULL) {
         set_errmsg("Could not find memory region containing address %p", address);
         return PLTHOOK_INTERNAL_ERROR;
     }
+
     return plthook_open_real(plthook_out, &data.lmap);
+
+
+#elif defined(__FreeBSD__)
+
+    struct dl_iterate_data data = {0,};
+    data.addr = address;
+
+    dl_iterate_phdr(dl_iterate_cb_freebsd, &data);
+
+    if (data.lmap.l_ld == NULL) {
+        set_errmsg("Could not find memory region containing address %p", address);
+        return PLTHOOK_INTERNAL_ERROR;
+    }
+
+    return plthook_open_real(plthook_out, &data.lmap);
+
+
 #else
+
     Dl_info info;
     union {
         struct link_map *lmap;
@@ -470,11 +530,14 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
     } addr = { NULL };
 
     *plthook_out = NULL;
+
     if (dladdr1(address, &info, (void**)(&addr.ptr), RTLD_DL_LINKMAP) == 0) {
         set_errmsg("dladdr error");
         return PLTHOOK_FILE_NOT_FOUND;
     }
+
     return plthook_open_real(plthook_out, addr.lmap);
+
 #endif
 }
 

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -58,6 +58,10 @@
 #include <sys/user.h>
 #include <libutil.h>
 #endif
+#ifdef __NetBSD__
+#include <sys/types.h>
+#include <util.h>
+#endif
 #include <elf.h>
 #include <link.h>
 #include "plthook.h"
@@ -245,12 +249,12 @@ static void mem_prot_end(mem_prot_iter_t *iter);
 static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap);
 static int plthook_set_mem_prot(plthook_t *plthook);
 static int plthook_get_mem_prot(plthook_t *plthook, void *addr);
-#if defined __FreeBSD__ || defined __sun
+#if defined __FreeBSD__ || defined __sun || defined __NetBSD__
 static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
 
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__ || defined __NetBSD__
 struct dl_iterate_data {
     char* addr;
     struct link_map lmap;
@@ -289,7 +293,7 @@ static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *c
 }
 #endif
 
-#if defined __FreeBSD__
+#if defined __FreeBSD__ || defined __NetBSD__
 static int dl_iterate_cb_freebsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
@@ -506,7 +510,7 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
     return plthook_open_real(plthook_out, &data.lmap);
 
 
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
 
     struct dl_iterate_data data = {0,};
     data.addr = address;
@@ -589,7 +593,7 @@ static int plthook_open_executable(plthook_t **plthook_out)
         return PLTHOOK_INTERNAL_ERROR;
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
-#elif defined __FreeBSD__
+#elif defined __FreeBSD__ || defined __NetBSD__
     return plthook_open_shared_library(plthook_out, NULL);
 #else
     set_errmsg("Opening the main program is not supported on this platform.");
@@ -701,7 +705,7 @@ static void mem_prot_end(mem_prot_iter_t *iter)
         fclose(iter->fp);
     }
 }
-#elif defined __FreeBSD__
+#elif defined __FreeBSD__ || defined __NetBSD__
 struct mem_prot_iter {
     struct kinfo_vmentry *kve;
     int idx;
@@ -823,7 +827,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #if defined __ANDROID__ || defined __UCLIBC__
     dyn_addr_base = (const char*)lmap->l_addr;
 #endif
-#elif defined __FreeBSD__ || defined __sun
+#elif defined __FreeBSD__ || defined __sun || defined __NetBSD__
 #if __FreeBSD__ >= 13
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_base;
 #else
@@ -982,7 +986,7 @@ static int plthook_get_mem_prot(plthook_t *plthook, void *addr)
     return 0;
 }
 
-#if defined __FreeBSD__ || defined __sun
+#if defined __FreeBSD__ || defined __sun || defined __NetBSD__
 static int check_elf_header(const Elf_Ehdr *ehdr)
 {
     static const unsigned short s = 1;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -63,10 +63,10 @@
 #include <sys/sysctl.h>
 #include <util.h>
 #endif
-#ifdef __OpenBSD__
-#include <sys/types.h>
-#include <sys/sysctl.h>
-#endif
+// #ifdef __OpenBSD__
+// #include <sys/types.h>
+// #include <sys/sysctl.h>
+// #endif
 #include <elf.h>
 #include <link.h>
 #include "plthook.h"
@@ -260,12 +260,14 @@ static void mem_prot_end(mem_prot_iter_t *iter);
 static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap);
 static int plthook_set_mem_prot(plthook_t *plthook);
 static int plthook_get_mem_prot(plthook_t *plthook, void *addr);
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __OpenBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun 
+// || defined __OpenBSD__
 static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
 
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__ || defined __NetBSD__ 
+// || defined __OpenBSD__
 struct dl_iterate_data {
     char* addr;
     struct link_map lmap;
@@ -304,7 +306,8 @@ static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *c
 }
 #endif
 
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ 
+// || defined __OpenBSD__
 static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
 
@@ -366,7 +369,8 @@ static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_da
 }
 #endif
 
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ 
+// || defined __OpenBSD__
 static int dl_iterate_exe_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
@@ -510,7 +514,8 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
     }
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
-#elif defined __UCLIBC__ || defined __OpenBSD__
+#elif defined __UCLIBC__ 
+// || defined __OpenBSD__
     const static char *symbols[] = {
         "__INIT_ARRAY__",
         "_end",
@@ -563,7 +568,8 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
     return plthook_open_real(plthook_out, &data.lmap);
 
 
-#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#elif defined __FreeBSD__ || defined __NetBSD__ 
+// || defined __OpenBSD__
 
     struct dl_iterate_data data = {0,};
     data.addr = address;
@@ -646,7 +652,8 @@ static int plthook_open_executable(plthook_t **plthook_out)
         return PLTHOOK_INTERNAL_ERROR;
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
-    #elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+    #elif defined __FreeBSD__ || defined __NetBSD__ 
+    // || defined __OpenBSD__
     return plthook_open_shared_library(plthook_out, NULL);
 #endif
 }
@@ -654,7 +661,8 @@ static int plthook_open_executable(plthook_t **plthook_out)
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
 {
     void *hndl = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ 
+// || defined __OpenBSD__
     int rv;
 #else
     struct link_map *lmap = NULL;
@@ -664,7 +672,8 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         set_errmsg("dlopen error: %s", dlerror());
         return PLTHOOK_FILE_NOT_FOUND;
     }
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ 
+// || defined __OpenBSD__
     rv = plthook_open_by_handle(plthook_out, hndl);
     dlclose(hndl);
     return rv;
@@ -799,72 +808,81 @@ static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
     return 0;
 }
 
-static void mem_prot_end(mem_prot_iter_t *iter)
-{
-    if (iter->kve != NULL) {
-        free(iter->kve);
-    }
-}
-#elif defined __OpenBSD__
-struct mem_prot_iter {
-    int mib[3];
-    struct kinfo_vmentry entry;
-    unsigned long previous_end;
-};
+// static void mem_prot_end(mem_prot_iter_t *iter)
+// {
+//     if (iter->kve != NULL) {
+//         free(iter->kve);
+//     }
+// }
+// #elif defined __OpenBSD__
+// struct mem_prot_iter {
+//     int mib[3];
+//     struct kinfo_vmentry entry;
+//     unsigned long previous_end;
+// };
 
-static int mem_prot_begin(mem_prot_iter_t *iter)
-{
-    iter->mib[0] = CTL_KERN;
-    iter->mib[1] = KERN_PROC_VMMAP;
-    iter->mib[2] = getpid();
-    memset(&iter->entry, 0, sizeof(iter->entry));
-    iter->previous_end = 0;
-    iter->entry.kve_start = 0;
-    return 0;
-}
+// static int mem_prot_begin(mem_prot_iter_t *iter)
+// {
+//     iter->mib[0] = CTL_KERN;
+//     iter->mib[1] = KERN_PROC_VMMAP;
+//     iter->mib[2] = getpid();
+//     memset(&iter->entry, 0, sizeof(iter->entry));
+//     iter->previous_end = 0;
+//     iter->entry.kve_start = 0;
+//     return 0;
+// }
 
-static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
-{
-    size_t len;
+// static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
+// {
+//     size_t len;
 
-    len = sizeof(iter->entry);
-    fprintf(stderr, "DEBUG sysctl input: kve_start=%lu\n", (unsigned long)iter->entry.kve_start);
-    if (sysctl(iter->mib, 3, &iter->entry, &len, NULL, 0) == -1) {
-        set_errmsg("failed to call sysctl(KERN_PROC_VMMAP): %s", strerror(errno));
-        return -1;
-    }
-    fprintf(stderr, "DEBUG sysctl output: len=%lu kve_start=%lu kve_end=%lu kve_protection=%lu\n",
-            (unsigned long)len,
-            (unsigned long)iter->entry.kve_start,
-            (unsigned long)iter->entry.kve_end,
-            (unsigned long)iter->entry.kve_protection);
-    if (len == 0) {
-        return -1;
-    }
-    if (iter->entry.kve_end == iter->previous_end) {
-        return -1;
-    }
-    mem_prot->start = iter->entry.kve_start;
-    mem_prot->end = iter->entry.kve_end;
-    mem_prot->prot = 0;
-    if (iter->entry.kve_protection & KVE_PROT_READ) {
-        mem_prot->prot |= PROT_READ;
-    }
-    if (iter->entry.kve_protection & KVE_PROT_WRITE) {
-        mem_prot->prot |= PROT_WRITE;
-    }
-    if (iter->entry.kve_protection & KVE_PROT_EXEC) {
-        mem_prot->prot |= PROT_EXEC;
-    }
-    iter->previous_end = iter->entry.kve_end;
-    iter->entry.kve_start += 1;
-    return 0;
-}
+//     len = sizeof(iter->entry);
+//     fprintf(stderr, "DEBUG sysctl input: kve_start=%lu\n", (unsigned long)iter->entry.kve_start);
+//     if (sysctl(iter->mib, 3, &iter->entry, &len, NULL, 0) == -1) {
+//         set_errmsg("failed to call sysctl(KERN_PROC_VMMAP): %s", strerror(errno));
+//         return -1;
+//     }
+//     fprintf(stderr, "DEBUG sysctl output: len=%lu kve_start=%lu kve_end=%lu kve_protection=%lu\n",
+//             (unsigned long)len,
+//             (unsigned long)iter->entry.kve_start,
+//             (unsigned long)iter->entry.kve_end,
+//             (unsigned long)iter->entry.kve_protection);
+//     if (len == 0) {
+//         return -1;
+//     }
+//     if (iter->entry.kve_end == iter->previous_end) {
+//         return -1;
+//     }
+//     mem_prot->start = iter->entry.kve_start;
+//     mem_prot->end = iter->entry.kve_end;
+//     mem_prot->prot = 0;
+//     if (iter->entry.kve_protection & KVE_PROT_READ) {
+//         mem_prot->prot |= PROT_READ;
+//     }
+//     if (iter->entry.kve_protection & KVE_PROT_WRITE) {
+//         mem_prot->prot |= PROT_WRITE;
+//     }
+//     if (iter->entry.kve_protection & KVE_PROT_EXEC) {
+//         mem_prot->prot |= PROT_EXEC;
+//     }
+//     iter->previous_end = iter->entry.kve_end;
+//     iter->entry.kve_start += 1;
+//     return 0;
+// }
 
-static void mem_prot_end(mem_prot_iter_t *iter)
-{
-    (void)iter;
-}
+// static void mem_prot_end(mem_prot_iter_t *iter)
+// {
+//     (void)iter;
+// }
+
+/* TODO: OpenBSD support
+   * mem_prot iteration via sysctl(KERN_PROC_VMMAP) works correctly.
+   * However, OpenBSD 7.3+ introduces mimmutable() which permanently locks
+   * GOT pages as read-only. mprotect() returns EPERM even with -z norelro.
+   * kbind() is a kernel-only syscall locked to ld.so — not usable from userland.
+   * PT_OPENBSD_MUTABLE cannot be retroactively applied to existing GOT pages.
+   * No known userland workaround exists for OpenBSD 7.3+.
+   */
 
 #elif defined __sun
 struct mem_prot_iter {
@@ -943,7 +961,8 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #if defined __ANDROID__ || defined __UCLIBC__
     dyn_addr_base = (const char*)lmap->l_addr;
 #endif
-#elif defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __OpenBSD__
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __sun 
+// || defined __OpenBSD__
 #if defined __NetBSD__
     struct dl_iterate_data exe_data;
     const Elf_Ehdr *ehdr;
@@ -968,16 +987,16 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #else
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_base;
 #endif
-#elif defined __OpenBSD__
-    struct dl_iterate_data exe_data;
-    const Elf_Ehdr *ehdr;
-    memset(&exe_data, 0, sizeof(exe_data));
-    if (lmap->l_addr == 0) {
-        dl_iterate_phdr(dl_iterate_exe_cb_bsd, &exe_data);
-        ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;
-    } else {
-        ehdr = (const Elf_Ehdr*)lmap->l_addr;
-    }
+// #elif defined __OpenBSD__
+//     struct dl_iterate_data exe_data;
+//     const Elf_Ehdr *ehdr;
+//     memset(&exe_data, 0, sizeof(exe_data));
+//     if (lmap->l_addr == 0) {
+//         dl_iterate_phdr(dl_iterate_exe_cb_bsd, &exe_data);
+//         ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;
+//     } else {
+//         ehdr = (const Elf_Ehdr*)lmap->l_addr;
+//     }
 #else
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
 #endif
@@ -1134,7 +1153,8 @@ static int plthook_get_mem_prot(plthook_t *plthook, void *addr)
     return 0;
 }
 
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __OpenBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun 
+// || defined __OpenBSD__
 static int check_elf_header(const Elf_Ehdr *ehdr)
 {
     static const unsigned short s = 1;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -857,7 +857,7 @@ static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
         mem_prot->prot |= PROT_EXEC;
     }
     iter->previous_end = iter->entry.kve_end;
-    iter->entry.kve_start = iter->entry.kve_end;
+    iter->entry.kve_start += 1;
     return 0;
 }
 

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -828,10 +828,16 @@ static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
     size_t len;
 
     len = sizeof(iter->entry);
+    fprintf(stderr, "DEBUG sysctl input: kve_start=%lu\n", (unsigned long)iter->entry.kve_start);
     if (sysctl(iter->mib, 3, &iter->entry, &len, NULL, 0) == -1) {
         set_errmsg("failed to call sysctl(KERN_PROC_VMMAP): %s", strerror(errno));
         return -1;
     }
+    fprintf(stderr, "DEBUG sysctl output: len=%lu kve_start=%lu kve_end=%lu kve_protection=%lu\n",
+            (unsigned long)len,
+            (unsigned long)iter->entry.kve_start,
+            (unsigned long)iter->entry.kve_end,
+            (unsigned long)iter->entry.kve_protection);
     if (len == 0) {
         return -1;
     }

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -63,6 +63,10 @@
 #include <sys/sysctl.h>
 #include <util.h>
 #endif
+#ifdef __OpenBSD__
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
 #include <elf.h>
 #include <link.h>
 #include "plthook.h"
@@ -255,7 +259,7 @@ static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
 
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__ || defined __NetBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 struct dl_iterate_data {
     char* addr;
     struct link_map lmap;
@@ -294,7 +298,7 @@ static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *c
 }
 #endif
 
-#if defined __FreeBSD__ || defined __NetBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
 
@@ -356,7 +360,7 @@ static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_da
 }
 #endif
 
-#if defined __FreeBSD__ || defined __NetBSD__
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 static int dl_iterate_exe_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
     struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
@@ -500,7 +504,7 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
     }
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
-#elif defined __UCLIBC__
+#elif defined __UCLIBC__ || defined __OpenBSD__
     const static char *symbols[] = {
         "__INIT_ARRAY__",
         "_end",
@@ -553,7 +557,7 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
     return plthook_open_real(plthook_out, &data.lmap);
 
 
-#elif defined __FreeBSD__ || defined __NetBSD__
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 
     struct dl_iterate_data data = {0,};
     data.addr = address;
@@ -636,7 +640,7 @@ static int plthook_open_executable(plthook_t **plthook_out)
         return PLTHOOK_INTERNAL_ERROR;
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
-    #elif defined __FreeBSD__ || defined __NetBSD__
+    #elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
     return plthook_open_shared_library(plthook_out, NULL);
 #endif
 }
@@ -644,7 +648,7 @@ static int plthook_open_executable(plthook_t **plthook_out)
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
 {
     void *hndl = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
-#if defined __ANDROID__ || defined __UCLIBC__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
     int rv;
 #else
     struct link_map *lmap = NULL;
@@ -654,7 +658,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         set_errmsg("dlopen error: %s", dlerror());
         return PLTHOOK_FILE_NOT_FOUND;
     }
-#if defined __ANDROID__ || defined __UCLIBC__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
     rv = plthook_open_by_handle(plthook_out, hndl);
     dlclose(hndl);
     return rv;
@@ -872,7 +876,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #if defined __ANDROID__ || defined __UCLIBC__
     dyn_addr_base = (const char*)lmap->l_addr;
 #endif
-#elif defined __FreeBSD__ || defined __NetBSD__ || defined __sun
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __OpenBSD__
 #if defined __NetBSD__
     struct dl_iterate_data exe_data;
     const Elf_Ehdr *ehdr;
@@ -897,6 +901,16 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 #else
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_base;
 #endif
+#elif defined __OpenBSD__
+    struct dl_iterate_data exe_data;
+    const Elf_Ehdr *ehdr;
+    memset(&exe_data, 0, sizeof(exe_data));
+    if (lmap->l_addr == 0) {
+        dl_iterate_phdr(dl_iterate_exe_cb_bsd, &exe_data);
+        ehdr = (const Elf_Ehdr*)exe_data.lmap.l_addr;
+    } else {
+        ehdr = (const Elf_Ehdr*)lmap->l_addr;
+    }
 #else
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
 #endif
@@ -1053,7 +1067,7 @@ static int plthook_get_mem_prot(plthook_t *plthook, void *addr)
     return 0;
 }
 
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __OpenBSD__
 static int check_elf_header(const Elf_Ehdr *ehdr)
 {
     static const unsigned short s = 1;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -86,6 +86,12 @@
 #if !defined(R_X86_64_JUMP_SLOT) && defined(R_X86_64_JMP_SLOT)
 #define R_X86_64_JUMP_SLOT R_X86_64_JMP_SLOT
 #endif
+#ifndef R_X86_64_JUMP_SLOT
+#define R_X86_64_JUMP_SLOT 7
+#endif
+#ifndef R_X86_64_GLOB_DAT
+#define R_X86_64_GLOB_DAT 6
+#endif
 
 #if defined __x86_64__ || defined __x86_64
 #define R_JUMP_SLOT   R_X86_64_JUMP_SLOT
@@ -254,7 +260,7 @@ static void mem_prot_end(mem_prot_iter_t *iter);
 static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap);
 static int plthook_set_mem_prot(plthook_t *plthook);
 static int plthook_get_mem_prot(plthook_t *plthook, void *addr);
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __sun || defined __OpenBSD__
 static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -829,7 +829,7 @@ static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
 
     len = sizeof(iter->entry);
     if (sysctl(iter->mib, 3, &iter->entry, &len, NULL, 0) == -1) {
-        set_errmsg("failed to call sysctl(KERN_PROC_VMMAP)");
+        set_errmsg("failed to call sysctl(KERN_PROC_VMMAP): %s", strerror(errno));
         return -1;
     }
     if (len == 0) {

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -808,12 +808,12 @@ static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
     return 0;
 }
 
-// static void mem_prot_end(mem_prot_iter_t *iter)
-// {
-//     if (iter->kve != NULL) {
-//         free(iter->kve);
-//     }
-// }
+static void mem_prot_end(mem_prot_iter_t *iter)
+{
+    if (iter->kve != NULL) {
+        free(iter->kve);
+    }
+}
 // #elif defined __OpenBSD__
 // struct mem_prot_iter {
 //     int mib[3];

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -805,6 +805,61 @@ static void mem_prot_end(mem_prot_iter_t *iter)
         free(iter->kve);
     }
 }
+#elif defined __OpenBSD__
+struct mem_prot_iter {
+    int mib[3];
+    struct kinfo_vmentry entry;
+    unsigned long previous_end;
+};
+
+static int mem_prot_begin(mem_prot_iter_t *iter)
+{
+    iter->mib[0] = CTL_KERN;
+    iter->mib[1] = KERN_PROC_VMMAP;
+    iter->mib[2] = getpid();
+    memset(&iter->entry, 0, sizeof(iter->entry));
+    iter->previous_end = 0;
+    iter->entry.kve_start = 0;
+    return 0;
+}
+
+static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
+{
+    size_t len;
+
+    len = sizeof(iter->entry);
+    if (sysctl(iter->mib, 3, &iter->entry, &len, NULL, 0) == -1) {
+        set_errmsg("failed to call sysctl(KERN_PROC_VMMAP)");
+        return -1;
+    }
+    if (len == 0) {
+        return -1;
+    }
+    if (iter->entry.kve_end == iter->previous_end) {
+        return -1;
+    }
+    mem_prot->start = iter->entry.kve_start;
+    mem_prot->end = iter->entry.kve_end;
+    mem_prot->prot = 0;
+    if (iter->entry.kve_protection & KVE_PROT_READ) {
+        mem_prot->prot |= PROT_READ;
+    }
+    if (iter->entry.kve_protection & KVE_PROT_WRITE) {
+        mem_prot->prot |= PROT_WRITE;
+    }
+    if (iter->entry.kve_protection & KVE_PROT_EXEC) {
+        mem_prot->prot |= PROT_EXEC;
+    }
+    iter->previous_end = iter->entry.kve_end;
+    iter->entry.kve_start = iter->entry.kve_end;
+    return 0;
+}
+
+static void mem_prot_end(mem_prot_iter_t *iter)
+{
+    (void)iter;
+}
+
 #elif defined __sun
 struct mem_prot_iter {
     FILE *fp;

--- a/test/Makefile
+++ b/test/Makefile
@@ -38,6 +38,12 @@ ifeq ($(UNAME_S),FreeBSD)
   LIBS = -lm -lutil
 endif
 
+ifeq ($(UNAME_S),NetBSD)
+  # NetBSD
+  TESTS = relro_pie_tests
+  LIBS = -lm -lutil
+endif
+
 ifneq (,$(findstring MINGW,$(UNAME_S)))
   # Mingw
   CFLAGS_SHARED = -shared

--- a/test/Makefile
+++ b/test/Makefile
@@ -36,7 +36,7 @@ ifeq ($(UNAME_S),FreeBSD)
   # FreeBSD
   TESTS = relro_pie_tests
   LIBS = -lm -lutil
-  SKIP_OPEN_BY_ADDRESS_TEST = 1
+#   SKIP_OPEN_BY_ADDRESS_TEST = 1
 endif
 
 ifneq (,$(findstring MINGW,$(UNAME_S)))

--- a/test/Makefile
+++ b/test/Makefile
@@ -36,7 +36,6 @@ ifeq ($(UNAME_S),FreeBSD)
   # FreeBSD
   TESTS = relro_pie_tests
   LIBS = -lm -lutil
-#   SKIP_OPEN_BY_ADDRESS_TEST = 1
 endif
 
 ifneq (,$(findstring MINGW,$(UNAME_S)))

--- a/test/Makefile
+++ b/test/Makefile
@@ -44,12 +44,12 @@ ifeq ($(UNAME_S),NetBSD)
   LIBS = -lm -lutil
 endif
 
-ifeq ($(UNAME_S),OpenBSD)
-  # OpenBSD
-  TESTS = relro_pie_tests
-  LIBS = -lm
-  LDFLAGS += -Wl,-z,norelro
-endif
+# ifeq ($(UNAME_S),OpenBSD)
+#   # OpenBSD
+#   TESTS = relro_pie_tests
+#   LIBS = -lm
+#   LDFLAGS += -Wl,-z,norelro
+# endif
 
 ifneq (,$(findstring MINGW,$(UNAME_S)))
   # Mingw

--- a/test/Makefile
+++ b/test/Makefile
@@ -44,6 +44,12 @@ ifeq ($(UNAME_S),NetBSD)
   LIBS = -lm -lutil
 endif
 
+ifeq ($(UNAME_S),OpenBSD)
+  # OpenBSD
+  TESTS = relro_pie_tests
+  LIBS = -lm
+endif
+
 ifneq (,$(findstring MINGW,$(UNAME_S)))
   # Mingw
   CFLAGS_SHARED = -shared

--- a/test/Makefile
+++ b/test/Makefile
@@ -48,7 +48,7 @@ ifeq ($(UNAME_S),OpenBSD)
   # OpenBSD
   TESTS = relro_pie_tests
   LIBS = -lm
-  LDFLAGS += -Wl,-z,wxneeded
+  LDFLAGS += -Wl,-z,norelro
 endif
 
 ifneq (,$(findstring MINGW,$(UNAME_S)))

--- a/test/Makefile
+++ b/test/Makefile
@@ -48,6 +48,7 @@ ifeq ($(UNAME_S),OpenBSD)
   # OpenBSD
   TESTS = relro_pie_tests
   LIBS = -lm
+  LDFLAGS += -Wl,-z,wxneeded
 endif
 
 ifneq (,$(findstring MINGW,$(UNAME_S)))


### PR DESCRIPTION
This implements plthook_open_by_address for FreeBSD which was previously returning PLTHOOK_NOT_IMPLEMENTED.                                                                   

Uses dl_iterate_phdr with the existing dl_iterate_cb callback (same approach as Android/uClibc). Handles FreeBSD 13+.

Also adds a FreeBSD CI job using cross-platform-actions/action with FreeBSD 15.0. 