### PR TITLE
Fix undefined behavior in address arithmetic causing -O2/-O3 failures on FreeBSD 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -325,4 +325,5 @@ jobs:
               sudo pkg_add -I gmake
             fi
             export OPT_CFLAGS="${{ matrix.optimization }}"
-            cd test && gmake relro_pie_tests
+            cd test && gmake relro_pie_tests || true
+            readelf -d testprog

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -326,4 +326,3 @@ jobs:
             fi
             export OPT_CFLAGS="${{ matrix.optimization }}"
             cd test && gmake relro_pie_tests
-            readelf -d testprog

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -293,7 +293,7 @@ jobs:
         architecture:
           - x86-64
           - arm64
-        optimization: ["", "-O2"]
+        optimization: ["", "-O2", "-O3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -293,6 +293,7 @@ jobs:
         architecture:
           - x86-64
           - arm64
+        optimization: ["", "-O3"]
 
     steps:
       - uses: actions/checkout@v4
@@ -323,4 +324,5 @@ jobs:
             elif [ "$OS" = "OpenBSD" ]; then
               sudo pkg_add -I gmake
             fi
+            export OPT_CFLAGS="${{ matrix.optimization }}"
             cd test && gmake relro_pie_tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -293,7 +293,7 @@ jobs:
         architecture:
           - x86-64
           - arm64
-        optimization: ["", "-O3"]
+        optimization: ["", "-O2"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -325,5 +325,5 @@ jobs:
               sudo pkg_add -I gmake
             fi
             export OPT_CFLAGS="${{ matrix.optimization }}"
-            cd test && gmake relro_pie_tests || true
+            cd test && gmake relro_pie_tests
             readelf -d testprog

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -671,9 +671,9 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         dlclose(hndl);
         return PLTHOOK_FILE_NOT_FOUND;
     }
-    fprintf(stderr, "DEBUG BEFORE dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)lmap->l_ld->d_tag);
+    fprintf(stderr, "DEBUG BEFORE dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)((const Elf_Dyn*)lmap->l_ld)->d_tag);
     dlclose(hndl);
-    fprintf(stderr, "DEBUG AFTER dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)lmap->l_ld->d_tag);
+    fprintf(stderr, "DEBUG AFTER dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)((const Elf_Dyn*)lmap->l_ld)->d_tag);
     return plthook_open_real(plthook_out, lmap);
 #endif
 }

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -937,6 +937,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     if (page_size == 0) {
         page_size = sysconf(_SC_PAGESIZE);
     }
+    fprintf(stderr, "DEBUG plthook_open_real: l_name='%s', l_addr=%p, l_ld=%p\n", lmap->l_name, (void*)lmap->l_addr, (void*)lmap->l_ld);
 
 #if defined __linux__
     plthook.plt_addr_base = (char*)lmap->l_addr;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -680,9 +680,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
 static const Elf_Dyn *find_dyn_by_tag(const Elf_Dyn *dyn, dyn_tag_t tag)
 {
     while (dyn->d_tag != DT_NULL) {
-        printf("dyn->d_tag: %" ELF_SXWORD_FMT "\n", (Elf_Sxword)dyn->d_tag);
         if (dyn->d_tag == tag) {
-            printf("Found dyn with tag: %" ELF_SXWORD_FMT "\n", (Elf_Sxword)dyn->d_tag);
             return dyn;
         }
         dyn++;
@@ -1003,7 +1001,6 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     if (rv_ != 0) {
         return rv_;
     }
-    printf("ehdr->e_type=%d ET_DYN=%d ET_EXEC=%d\n",ehdr->e_type,ET_DYN,ET_EXEC);
     if (ehdr->e_type == ET_DYN) {
         dyn_addr_base = (uintptr_t)lmap->l_addr;
         plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
@@ -1046,24 +1043,11 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         return PLTHOOK_INTERNAL_ERROR;
     }
     plthook.dynstr_size = dyn->d_un.d_val;
-    // {
-    //     const Elf_Dyn *dbg = lmap->l_ld;
-    //     int i;
-    //     fprintf(stderr, "DEBUG find_dyn_by_tag start: lmap->l_ld=%p\n", (void*)lmap->l_ld);
-    //     for (i = 0; i < 30 && dbg->d_tag != DT_NULL; i++, dbg++) {
-    //         fprintf(stderr, "DEBUG dyn[%d]: tag=%ld (0x%lx)\n", i, (long)dbg->d_tag, (unsigned long)dbg->d_tag);
-    //     }
-    // }
     /* Get .rela.plt or .rel.plt section */
-    printf("lmap->l_ld: %p\n", (void*)lmap->l_ld);
     dyn = find_dyn_by_tag(lmap->l_ld, DT_JMPREL);
     if (dyn != NULL) {
         plthook.rela_plt = (const Elf_Plt_Rel *)(dyn_addr_base + (uintptr_t)dyn->d_un.d_ptr);
         dyn = find_dyn_by_tag(lmap->l_ld, DT_PLTRELSZ);
-        printf("DT_JMPREL: base=%#lx d_ptr=%#lx rela_plt=%p\n",
-       (unsigned long)dyn_addr_base,
-       (unsigned long)dyn->d_un.d_ptr,
-       (void*)plthook.rela_plt);
         if (dyn == NULL) {
             set_errmsg("failed to find DT_PLTRELSZ");
             return PLTHOOK_INTERNAL_ERROR;
@@ -1078,10 +1062,6 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 
         plthook.rela_dyn = (const Elf_Plt_Rel *)(dyn_addr_base + (uintptr_t)dyn->d_un.d_ptr);
         dyn = find_dyn_by_tag(lmap->l_ld, PLT_DT_RELSZ);
-        printf("PLT_DT_REL: dyn_addr_base=%#lx d_ptr=%#lx rela_dyn=%p\n",
-           (unsigned long)dyn_addr_base,
-           (unsigned long)dyn->d_un.d_ptr,
-           (void*)plthook.rela_dyn);
         if (dyn == NULL) {
             set_errmsg("failed to find PLT_DT_RELSZ");
             return PLTHOOK_INTERNAL_ERROR;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -1047,7 +1047,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         const Elf_Dyn *dbg = lmap->l_ld;
         int i;
         fprintf(stderr, "DEBUG find_dyn_by_tag start: lmap->l_ld=%p\n", (void*)lmap->l_ld);
-        for (i = 0; i < 5 && dbg->d_tag != DT_NULL; i++, dbg++) {
+        for (i = 0; i < 30 && dbg->d_tag != DT_NULL; i++, dbg++) {
             fprintf(stderr, "DEBUG dyn[%d]: tag=%ld (0x%lx)\n", i, (long)dbg->d_tag, (unsigned long)dbg->d_tag);
         }
     }

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -679,6 +679,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
 static const Elf_Dyn *find_dyn_by_tag(const Elf_Dyn *dyn, dyn_tag_t tag)
 {
     while (dyn->d_tag != DT_NULL) {
+        printf("dyn->d_tag: %" ELF_SXWORD_FMT "\n", (Elf_Sxword)dyn->d_tag);
         if (dyn->d_tag == tag) {
             return dyn;
         }

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -671,7 +671,9 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         dlclose(hndl);
         return PLTHOOK_FILE_NOT_FOUND;
     }
+    fprintf(stderr, "DEBUG BEFORE dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)lmap->l_ld->d_tag);
     dlclose(hndl);
+    fprintf(stderr, "DEBUG AFTER dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)lmap->l_ld->d_tag);
     return plthook_open_real(plthook_out, lmap);
 #endif
 }
@@ -937,7 +939,6 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     if (page_size == 0) {
         page_size = sysconf(_SC_PAGESIZE);
     }
-    fprintf(stderr, "DEBUG plthook_open_real: l_name='%s', l_addr=%p, l_ld=%p\n", lmap->l_name, (void*)lmap->l_addr, (void*)lmap->l_ld);
 
 #if defined __linux__
     plthook.plt_addr_base = (char*)lmap->l_addr;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -681,6 +681,7 @@ static const Elf_Dyn *find_dyn_by_tag(const Elf_Dyn *dyn, dyn_tag_t tag)
     while (dyn->d_tag != DT_NULL) {
         printf("dyn->d_tag: %" ELF_SXWORD_FMT "\n", (Elf_Sxword)dyn->d_tag);
         if (dyn->d_tag == tag) {
+            printf("Found dyn with tag: %" ELF_SXWORD_FMT "\n", (Elf_Sxword)dyn->d_tag);
             return dyn;
         }
         dyn++;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -1043,7 +1043,14 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         return PLTHOOK_INTERNAL_ERROR;
     }
     plthook.dynstr_size = dyn->d_un.d_val;
-
+    {
+        const Elf_Dyn *dbg = lmap->l_ld;
+        int i;
+        fprintf(stderr, "DEBUG find_dyn_by_tag start: lmap->l_ld=%p\n", (void*)lmap->l_ld);
+        for (i = 0; i < 5 && dbg->d_tag != DT_NULL; i++, dbg++) {
+            fprintf(stderr, "DEBUG dyn[%d]: tag=%ld (0x%lx)\n", i, (long)dbg->d_tag, (unsigned long)dbg->d_tag);
+        }
+    }
     /* Get .rela.plt or .rel.plt section */
     dyn = find_dyn_by_tag(lmap->l_ld, DT_JMPREL);
     if (dyn != NULL) {

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -1060,7 +1060,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         plthook.rela_plt = (const Elf_Plt_Rel *)(dyn_addr_base + dyn->d_un.d_ptr);
         dyn = find_dyn_by_tag(lmap->l_ld, DT_PLTRELSZ);
         printf("DT_JMPREL: base=%#lx d_ptr=%#lx rela_plt=%p\n",
-       (unsigned long)base,
+       (unsigned long)dyn_addr_base,
        (unsigned long)dyn->d_un.d_ptr,
        (void*)plthook.rela_plt);
         if (dyn == NULL) {

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -1043,14 +1043,14 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         return PLTHOOK_INTERNAL_ERROR;
     }
     plthook.dynstr_size = dyn->d_un.d_val;
-    {
-        const Elf_Dyn *dbg = lmap->l_ld;
-        int i;
-        fprintf(stderr, "DEBUG find_dyn_by_tag start: lmap->l_ld=%p\n", (void*)lmap->l_ld);
-        for (i = 0; i < 30 && dbg->d_tag != DT_NULL; i++, dbg++) {
-            fprintf(stderr, "DEBUG dyn[%d]: tag=%ld (0x%lx)\n", i, (long)dbg->d_tag, (unsigned long)dbg->d_tag);
-        }
-    }
+    // {
+    //     const Elf_Dyn *dbg = lmap->l_ld;
+    //     int i;
+    //     fprintf(stderr, "DEBUG find_dyn_by_tag start: lmap->l_ld=%p\n", (void*)lmap->l_ld);
+    //     for (i = 0; i < 30 && dbg->d_tag != DT_NULL; i++, dbg++) {
+    //         fprintf(stderr, "DEBUG dyn[%d]: tag=%ld (0x%lx)\n", i, (long)dbg->d_tag, (unsigned long)dbg->d_tag);
+    //     }
+    // }
     /* Get .rela.plt or .rel.plt section */
     dyn = find_dyn_by_tag(lmap->l_ld, DT_JMPREL);
     if (dyn != NULL) {

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -1002,6 +1002,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     if (rv_ != 0) {
         return rv_;
     }
+    printf("ehdr->e_type=%d ET_DYN=%d ET_EXEC=%d\n",ehdr->e_type,ET_DYN,ET_EXEC);
     if (ehdr->e_type == ET_DYN) {
         dyn_addr_base = (const char*)lmap->l_addr;
         plthook.plt_addr_base = (const char*)lmap->l_addr;
@@ -1058,6 +1059,10 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     if (dyn != NULL) {
         plthook.rela_plt = (const Elf_Plt_Rel *)(dyn_addr_base + dyn->d_un.d_ptr);
         dyn = find_dyn_by_tag(lmap->l_ld, DT_PLTRELSZ);
+        printf("DT_JMPREL: base=%#lx d_ptr=%#lx rela_plt=%p\n",
+       (unsigned long)base,
+       (unsigned long)dyn->d_un.d_ptr,
+       (void*)plthook.rela_plt);
         if (dyn == NULL) {
             set_errmsg("failed to find DT_PLTRELSZ");
             return PLTHOOK_INTERNAL_ERROR;
@@ -1072,6 +1077,10 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 
         plthook.rela_dyn = (const Elf_Plt_Rel *)(dyn_addr_base + dyn->d_un.d_ptr);
         dyn = find_dyn_by_tag(lmap->l_ld, PLT_DT_RELSZ);
+        printf("PLT_DT_REL: dyn_addr_base=%p d_ptr=%#lx rela_dyn=%p\n",
+           (void*)dyn_addr_base,
+           (unsigned long)dyn->d_un.d_ptr,
+           (void*)plthook.rela_dyn);
         if (dyn == NULL) {
             set_errmsg("failed to find PLT_DT_RELSZ");
             return PLTHOOK_INTERNAL_ERROR;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -671,9 +671,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         dlclose(hndl);
         return PLTHOOK_FILE_NOT_FOUND;
     }
-    fprintf(stderr, "DEBUG BEFORE dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)((const Elf_Dyn*)lmap->l_ld)->d_tag);
     dlclose(hndl);
-    fprintf(stderr, "DEBUG AFTER dlclose: l_ld=%p, first_tag=%ld\n", (void*)lmap->l_ld, (long)((const Elf_Dyn*)lmap->l_ld)->d_tag);
     return plthook_open_real(plthook_out, lmap);
 #endif
 }
@@ -1053,6 +1051,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     //     }
     // }
     /* Get .rela.plt or .rel.plt section */
+    printf("lmap->l_ld: %p\n", (void*)lmap->l_ld);
     dyn = find_dyn_by_tag(lmap->l_ld, DT_JMPREL);
     if (dyn != NULL) {
         plthook.rela_plt = (const Elf_Plt_Rel *)(dyn_addr_base + dyn->d_un.d_ptr);

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -44,6 +44,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdint.h>
 #include <limits.h>
 #include <sys/mman.h>
 #include <errno.h>
@@ -238,7 +239,7 @@ struct plthook {
     const Elf_Sym *dynsym;
     const char *dynstr;
     size_t dynstr_size;
-    const char *plt_addr_base;
+    uintptr_t plt_addr_base;
     const Elf_Plt_Rel *rela_plt;
     size_t rela_plt_cnt;
 #ifdef R_GLOBAL_DATA
@@ -934,22 +935,22 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 {
     plthook_t plthook = {0};
     const Elf_Dyn *dyn;
-    const char *dyn_addr_base = NULL;
+    uintptr_t dyn_addr_base = 0;
 
     if (page_size == 0) {
         page_size = sysconf(_SC_PAGESIZE);
     }
 
 #if defined __linux__
-    plthook.plt_addr_base = (char*)lmap->l_addr;
+    plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
 #if defined __riscv
     const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
     if (ehdr->e_type == ET_DYN) {
-        dyn_addr_base = (const char*)lmap->l_addr;
+        dyn_addr_base = (uintptr_t)lmap->l_addr;
     }
 #endif
 #if defined __ANDROID__ || defined __UCLIBC__
-    dyn_addr_base = (const char*)lmap->l_addr;
+    dyn_addr_base = (uintptr_t)lmap->l_addr;
 #endif
 #elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __sun
 #if defined __NetBSD__
@@ -1004,8 +1005,8 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     }
     printf("ehdr->e_type=%d ET_DYN=%d ET_EXEC=%d\n",ehdr->e_type,ET_DYN,ET_EXEC);
     if (ehdr->e_type == ET_DYN) {
-        dyn_addr_base = (const char*)lmap->l_addr;
-        plthook.plt_addr_base = (const char*)lmap->l_addr;
+        dyn_addr_base = (uintptr_t)lmap->l_addr;
+        plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
     }
 #else
 #error unsupported OS
@@ -1017,7 +1018,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         set_errmsg("failed to find DT_SYMTAB");
         return PLTHOOK_INTERNAL_ERROR;
     }
-    plthook.dynsym = (const Elf_Sym*)(dyn_addr_base + dyn->d_un.d_ptr);
+    plthook.dynsym = (const Elf_Sym*)(dyn_addr_base + (uintptr_t)dyn->d_un.d_ptr);
 
     /* Check sizeof(Elf_Sym) */
     dyn = find_dyn_by_tag(lmap->l_ld, DT_SYMENT);
@@ -1036,7 +1037,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         set_errmsg("failed to find DT_STRTAB");
         return PLTHOOK_INTERNAL_ERROR;
     }
-    plthook.dynstr = dyn_addr_base + dyn->d_un.d_ptr;
+    plthook.dynstr = (const char *)(dyn_addr_base + (uintptr_t)dyn->d_un.d_ptr);
 
     /* Get .dynstr size */
     dyn = find_dyn_by_tag(lmap->l_ld, DT_STRSZ);
@@ -1057,7 +1058,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     printf("lmap->l_ld: %p\n", (void*)lmap->l_ld);
     dyn = find_dyn_by_tag(lmap->l_ld, DT_JMPREL);
     if (dyn != NULL) {
-        plthook.rela_plt = (const Elf_Plt_Rel *)(dyn_addr_base + dyn->d_un.d_ptr);
+        plthook.rela_plt = (const Elf_Plt_Rel *)(dyn_addr_base + (uintptr_t)dyn->d_un.d_ptr);
         dyn = find_dyn_by_tag(lmap->l_ld, DT_PLTRELSZ);
         printf("DT_JMPREL: base=%#lx d_ptr=%#lx rela_plt=%p\n",
        (unsigned long)dyn_addr_base,
@@ -1075,10 +1076,10 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     if (dyn != NULL) {
         size_t total_size, elem_size;
 
-        plthook.rela_dyn = (const Elf_Plt_Rel *)(dyn_addr_base + dyn->d_un.d_ptr);
+        plthook.rela_dyn = (const Elf_Plt_Rel *)(dyn_addr_base + (uintptr_t)dyn->d_un.d_ptr);
         dyn = find_dyn_by_tag(lmap->l_ld, PLT_DT_RELSZ);
-        printf("PLT_DT_REL: dyn_addr_base=%p d_ptr=%#lx rela_dyn=%p\n",
-           (void*)dyn_addr_base,
+        printf("PLT_DT_REL: dyn_addr_base=%#lx d_ptr=%#lx rela_dyn=%p\n",
+           (unsigned long)dyn_addr_base,
            (unsigned long)dyn->d_un.d_ptr,
            (void*)plthook.rela_dyn);
         if (dyn == NULL) {
@@ -1227,7 +1228,7 @@ static int check_rel(const plthook_t *plthook, const Elf_Plt_Rel *plt, Elf_Xword
             return PLTHOOK_INVALID_FILE_FORMAT;
         }
         *name_out = plthook->dynstr + idx;
-        *addr_out = (void**)(plthook->plt_addr_base + plt->r_offset);
+        *addr_out = (void**)(plthook->plt_addr_base + (uintptr_t)plt->r_offset);
         DEBUG_MSG("%s (%p)\n", *name_out, (void *)(*addr_out));
         return 0;
     }

--- a/test/android/run_tests.sh
+++ b/test/android/run_tests.sh
@@ -21,6 +21,9 @@ ABI=x86_64
 
 adb root || true
 adb wait-for-device
+adb logcat -c
+adb logcat > /tmp/android_logcat.txt &
+LOGCAT_PID=$!
 
 adb push "libs/$ABI/libtest.so" /data/local/tmp/
 adb push "libs/$ABI/testprog"   /data/local/tmp/
@@ -31,3 +34,6 @@ run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_
 run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_handle"
 
 echo "All Android tests passed!"
+kill $LOGCAT_PID || true
+echo "=== Logcat output ==="
+cat /tmp/android_logcat.txt

--- a/test/android/run_tests.sh
+++ b/test/android/run_tests.sh
@@ -31,4 +31,3 @@ run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_
 run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_handle"
 
 echo "All Android tests passed!"
-

--- a/test/android/run_tests.sh
+++ b/test/android/run_tests.sh
@@ -21,9 +21,6 @@ ABI=x86_64
 
 adb root || true
 adb wait-for-device
-adb logcat -c
-adb logcat > /tmp/android_logcat.txt &
-LOGCAT_PID=$!
 
 adb push "libs/$ABI/libtest.so" /data/local/tmp/
 adb push "libs/$ABI/testprog"   /data/local/tmp/
@@ -34,6 +31,4 @@ run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_
 run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_handle"
 
 echo "All Android tests passed!"
-kill $LOGCAT_PID || true
-echo "=== Logcat output ==="
-cat /tmp/android_logcat.txt
+


### PR DESCRIPTION
## Summary

Fix undefined behavior in address arithmetic for non-PIE (`ET_EXEC`) binaries on FreeBSD.

`plthook_open(&plthook, NULL)` could fail on FreeBSD 15.0 when compiled with `-O2` or `-O3`:

```text
failed to find either of DT_JMPREL and DT_REL
```

The issue was caused by pointer arithmetic on a `NULL` base address:

```c
dyn_addr_base + dyn->d_un.d_ptr
```

For `ET_EXEC` binaries, `dyn_addr_base` remains `NULL`, so this expression invokes undefined behavior. Under optimization, clang may miscompile later checks even though the dynamic tags are found correctly.

This patch replaces pointer-based base arithmetic with `uintptr_t` integer arithmetic and casts back to pointers only after the final address is computed. This makes address computation well-defined for both `ET_EXEC` and `ET_DYN` objects.

The same fix applies to:

* `rela_plt`
* `rela_dyn`
* `dynsym`
* `dynstr`
* `plt_addr_base`

## Testing

Tested on FreeBSD 15.0:

* x86-64
* arm64
* `-O0`
* `-O2`
* `-O3`

All existing tests pass.
