### PR TITLE
Add Haiku OS support

### DIFF
--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -31,13 +31,5 @@ jobs:
           architecture: x86-64
           shell: sh
           run: |
-            export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
-            cd test && make clean libtest.so testprog
-            echo "=== handle debug ==="
-            printf '#include <stdio.h>\n#include <dlfcn.h>\n#include <link.h>\n#ifndef RTLD_NOLOAD\n#define RTLD_NOLOAD 4\n#endif\nstatic int cb(struct dl_phdr_info *info, size_t size, void *data) {\n  void *h;\n  (void)size;\n  printf("name=[%%s]\\n", info->dlpi_name ? info->dlpi_name : "(null)");\n  h = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);\n  printf("  dlopen handle=%%p target=%%p match=%%d\\n", h, data, h == data);\n  if(h) dlclose(h);\n  return 0;\n}\nint main() {\n  void *h = dlopen("libtest.so", RTLD_LAZY | RTLD_NOLOAD);\n  printf("target handle: %%p\\n", h);\n  dl_iterate_phdr(cb, h);\n  return 0;\n}\n' > /tmp/htest.c
-            cc /tmp/htest.c -o /tmp/htest -lbsd -L. -ltest -Wl,-rpath,.
-            /tmp/htest
-            echo "===  tests ==="
-            ./testprog open 2>&1 || echo "open exit code: $?"
-            ./testprog open_by_handle 2>&1 || echo "open_by_handle exit code: $?"
-            ./testprog open_by_address 2>&1 || echo "open_by_address exit code: $?"
+            export OPT_CFLAGS="${{ matrix.optimization }}"
+            cd test && make check

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -34,7 +34,7 @@ jobs:
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
             echo "=== handle debug ==="
-            printf '#include <stdio.h>\n#include <dlfcn.h>\n#include <link.h>\nstatic int cb(struct dl_phdr_info *info, size_t size, void *data) {\n  void *h;\n  (void)size;\n  printf("name=[%%s]\\n", info->dlpi_name ? info->dlpi_name : "(null)");\n  h = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);\n  printf("  dlopen handle=%%p target=%%p match=%%d\\n", h, data, h == data);\n  if(h) dlclose(h);\n  return 0;\n}\nint main() {\n  void *h = dlopen("libtest.so", RTLD_LAZY | RTLD_NOLOAD);\n  printf("target handle: %%p\\n", h);\n  dl_iterate_phdr(cb, h);\n  return 0;\n}\n' > /tmp/htest.c
+            printf '#include <stdio.h>\n#include <dlfcn.h>\n#include <link.h>\n#ifndef RTLD_NOLOAD\n#define RTLD_NOLOAD 4\n#endif\nstatic int cb(struct dl_phdr_info *info, size_t size, void *data) {\n  void *h;\n  (void)size;\n  printf("name=[%%s]\\n", info->dlpi_name ? info->dlpi_name : "(null)");\n  h = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);\n  printf("  dlopen handle=%%p target=%%p match=%%d\\n", h, data, h == data);\n  if(h) dlclose(h);\n  return 0;\n}\nint main() {\n  void *h = dlopen("libtest.so", RTLD_LAZY | RTLD_NOLOAD);\n  printf("target handle: %%p\\n", h);\n  dl_iterate_phdr(cb, h);\n  return 0;\n}\n' > /tmp/htest.c
             cc /tmp/htest.c -o /tmp/htest -lbsd -L. -ltest -Wl,-rpath,.
             /tmp/htest
             echo "===  tests ==="

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -33,4 +33,8 @@ jobs:
           run: |
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
-            LIBRARY_PATH=. LD_LIBRARY_PATH=. ./testprog open 2>&1 || echo "exit code: $?"
+            ls -la libtest.so testprog
+            file testprog
+            readelf -d testprog | grep NEEDED || true
+            echo "--- attempting to run ---"
+            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1; echo "exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -33,27 +33,7 @@ jobs:
           run: |
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
-            echo "=== testprog ELF info ==="
-            readelf -h testprog
-            readelf -l testprog
-            readelf -d testprog
-            echo "=== libtest.so ELF info ==="
-            readelf -d libtest.so
-            echo "=== undefined symbols in testprog ==="
-            readelf -Ws testprog | grep UND || true
-            echo "=== relocations mentioning dl_iterate_phdr ==="
-            readelf -r testprog | grep dl_iterate_phdr || true
-            echo "=== runtime libbsd dl_iterate_phdr ==="
-            readelf -Ws /boot/system/lib/libbsd.so | grep dl_iterate_phdr || true
-            readelf -Ws /boot/system/develop/lib/libbsd.so | grep dl_iterate_phdr || true
-            echo "=== direct dl_iterate_phdr runtime test ==="
-            printf '#include <link.h>\nstatic int cb(struct dl_phdr_info *info, size_t size, void *data) { return 0; }\nint main(void) { return dl_iterate_phdr(cb, 0); }\n' > /tmp/dlphdr.c
-            cc /tmp/dlphdr.c -o /tmp/dlphdr -lbsd
-            /tmp/dlphdr || echo "dlphdr exit code: $?"
-            echo "=== LIBRARY_PATH theory test ==="
-            echo "test 1: no LIBRARY_PATH (RPATH . should find libtest.so)"
-            ./testprog open 2>&1 || echo "no-LIBRARY_PATH exit code: $?"
-            echo "test 2: LIBRARY_PATH with system libs included"
-            LIBRARY_PATH="$(pwd):/boot/system/lib" ./testprog open 2>&1 || echo "with-syslibs exit code: $?"
-            echo "test 3: LIBRARY_PATH=$(pwd) only (current broken approach)"
-            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "pwd-only exit code: $?"
+            echo "===  tests ==="
+            ./testprog open 2>&1 || echo "open exit code: $?"
+            ./testprog open_by_handle 2>&1 || echo "open_by_handle exit code: $?"
+            ./testprog open_by_address 2>&1 || echo "open_by_address exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -33,9 +33,13 @@ jobs:
           run: |
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
-            ls -la /boot/system/lib/libbsd* || echo "libbsd not in system lib"
-            find /boot -name "libbsd.so" 2>/dev/null || echo "libbsd.so not found"
-            echo 'int main(){return 0;}' > /tmp/hello.c
-            cc /tmp/hello.c -o /tmp/hello -lbsd && /tmp/hello && echo "minimal libbsd test OK" || echo "minimal libbsd test FAILED: $?"
-            echo "--- attempting testprog ---"
+            echo "=== testprog ELF info ==="
+            readelf -h testprog
+            readelf -l testprog
+            readelf -d testprog
+            echo "=== libtest.so ELF info ==="
+            readelf -d libtest.so
+            echo "=== check libm ==="
+            ls -la /boot/system/lib/libm* 2>/dev/null || echo "no libm in system lib"
+            echo "=== run testprog ==="
             LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -33,4 +33,4 @@ jobs:
           run: |
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
-            LD_LIBRARY_PATH=. ./testprog open 2>&1 || echo "exit code: $?"
+            LIBRARY_PATH=. LD_LIBRARY_PATH=. ./testprog open 2>&1 || echo "exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -39,7 +39,8 @@ jobs:
             readelf -d testprog
             echo "=== libtest.so ELF info ==="
             readelf -d libtest.so
-            echo "=== check libm ==="
-            ls -la /boot/system/lib/libm* 2>/dev/null || echo "no libm in system lib"
-            echo "=== run testprog ==="
-            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "exit code: $?"
+            echo "=== smoke tests ==="
+            LIBRARY_PATH="$(pwd)" ./testprog 2>&1 || echo "no-arg exit code: $?"
+            LIBRARY_PATH="$(pwd)" ./testprog open_by_address 2>&1 || echo "open_by_address exit code: $?"
+            LIBRARY_PATH="$(pwd)" ./testprog open_by_handle 2>&1 || echo "open_by_handle exit code: $?"
+            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "open exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -39,6 +39,17 @@ jobs:
             readelf -d testprog
             echo "=== libtest.so ELF info ==="
             readelf -d libtest.so
+            echo "=== undefined symbols in testprog ==="
+            readelf -Ws testprog | grep UND || true
+            echo "=== relocations mentioning dl_iterate_phdr ==="
+            readelf -r testprog | grep dl_iterate_phdr || true
+            echo "=== runtime libbsd dl_iterate_phdr ==="
+            readelf -Ws /boot/system/lib/libbsd.so | grep dl_iterate_phdr || true
+            readelf -Ws /boot/system/develop/lib/libbsd.so | grep dl_iterate_phdr || true
+            echo "=== direct dl_iterate_phdr runtime test ==="
+            printf '#include <link.h>\nstatic int cb(struct dl_phdr_info *info, size_t size, void *data) { return 0; }\nint main(void) { return dl_iterate_phdr(cb, 0); }\n' > /tmp/dlphdr.c
+            cc /tmp/dlphdr.c -o /tmp/dlphdr -lbsd
+            /tmp/dlphdr || echo "dlphdr exit code: $?"
             echo "=== smoke tests ==="
             LIBRARY_PATH="$(pwd)" ./testprog 2>&1 || echo "no-arg exit code: $?"
             LIBRARY_PATH="$(pwd)" ./testprog open_by_address 2>&1 || echo "open_by_address exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -33,8 +33,9 @@ jobs:
           run: |
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
-            ls -la libtest.so testprog
-            readelf -d testprog | grep NEEDED || true
-            readelf -d testprog | grep RPATH || echo "no RPATH set"
-            echo "--- attempting to run ---"
+            ls -la /boot/system/lib/libbsd* || echo "libbsd not in system lib"
+            find /boot -name "libbsd.so" 2>/dev/null || echo "libbsd.so not found"
+            echo 'int main(){return 0;}' > /tmp/hello.c
+            cc /tmp/hello.c -o /tmp/hello -lbsd && /tmp/hello && echo "minimal libbsd test OK" || echo "minimal libbsd test FAILED: $?"
+            echo "--- attempting testprog ---"
             LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -33,6 +33,10 @@ jobs:
           run: |
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
+            echo "=== handle debug ==="
+            printf '#include <stdio.h>\n#include <dlfcn.h>\n#include <link.h>\nstatic int cb(struct dl_phdr_info *info, size_t size, void *data) {\n  void *h;\n  (void)size;\n  printf("name=[%%s]\\n", info->dlpi_name ? info->dlpi_name : "(null)");\n  h = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);\n  printf("  dlopen handle=%%p target=%%p match=%%d\\n", h, data, h == data);\n  if(h) dlclose(h);\n  return 0;\n}\nint main() {\n  void *h = dlopen("libtest.so", RTLD_LAZY | RTLD_NOLOAD);\n  printf("target handle: %%p\\n", h);\n  dl_iterate_phdr(cb, h);\n  return 0;\n}\n' > /tmp/htest.c
+            cc /tmp/htest.c -o /tmp/htest -lbsd -L. -ltest -Wl,-rpath,.
+            /tmp/htest
             echo "===  tests ==="
             ./testprog open 2>&1 || echo "open exit code: $?"
             ./testprog open_by_handle 2>&1 || echo "open_by_handle exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Test on Haiku
-        uses: cross-platform-actions/action@v0.32.0
+        uses: cross-platform-actions/action@v1.2.0
         with:
           operating_system: haiku
           version: r1beta5

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -34,7 +34,7 @@ jobs:
             export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
             cd test && make clean libtest.so testprog
             ls -la libtest.so testprog
-            file testprog
             readelf -d testprog | grep NEEDED || true
+            readelf -d testprog | grep RPATH || echo "no RPATH set"
             echo "--- attempting to run ---"
-            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1; echo "exit code: $?"
+            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -1,0 +1,35 @@
+name: Haiku Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - haiku-support
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests_on_haiku:
+    name: Tests on Haiku
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        optimization: ["", "-O2", "-O3"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test on Haiku
+        uses: cross-platform-actions/action@v0.32.0
+        with:
+          operating_system: haiku
+          version: r1beta5
+          architecture: x86-64
+          shell: sh
+          run: |
+            export OPT_CFLAGS="${{ matrix.optimization }}"
+            cd test && make check

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -31,5 +31,6 @@ jobs:
           architecture: x86-64
           shell: sh
           run: |
-            export OPT_CFLAGS="${{ matrix.optimization }}"
-            cd test && make check
+            export OPT_CFLAGS="${{ matrix.optimization }} -DPLTHOOK_DEBUG"
+            cd test && make clean libtest.so testprog
+            LD_LIBRARY_PATH=. ./testprog open 2>&1 || echo "exit code: $?"

--- a/.github/workflows/haiku-tests.yml
+++ b/.github/workflows/haiku-tests.yml
@@ -50,8 +50,10 @@ jobs:
             printf '#include <link.h>\nstatic int cb(struct dl_phdr_info *info, size_t size, void *data) { return 0; }\nint main(void) { return dl_iterate_phdr(cb, 0); }\n' > /tmp/dlphdr.c
             cc /tmp/dlphdr.c -o /tmp/dlphdr -lbsd
             /tmp/dlphdr || echo "dlphdr exit code: $?"
-            echo "=== smoke tests ==="
-            LIBRARY_PATH="$(pwd)" ./testprog 2>&1 || echo "no-arg exit code: $?"
-            LIBRARY_PATH="$(pwd)" ./testprog open_by_address 2>&1 || echo "open_by_address exit code: $?"
-            LIBRARY_PATH="$(pwd)" ./testprog open_by_handle 2>&1 || echo "open_by_handle exit code: $?"
-            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "open exit code: $?"
+            echo "=== LIBRARY_PATH theory test ==="
+            echo "test 1: no LIBRARY_PATH (RPATH . should find libtest.so)"
+            ./testprog open 2>&1 || echo "no-LIBRARY_PATH exit code: $?"
+            echo "test 2: LIBRARY_PATH with system libs included"
+            LIBRARY_PATH="$(pwd):/boot/system/lib" ./testprog open 2>&1 || echo "with-syslibs exit code: $?"
+            echo "test 3: LIBRARY_PATH=$(pwd) only (current broken approach)"
+            LIBRARY_PATH="$(pwd)" ./testprog open 2>&1 || echo "pwd-only exit code: $?"

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -68,6 +68,9 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
+#ifdef __HAIKU__
+#include <OS.h>
+#endif
 #include <elf.h>
 #if defined __OpenBSD__ && (defined __aarch64__ || defined __aarch64)
 #define R_AARCH64_GLOB_DAT 1025
@@ -76,7 +79,7 @@
 #include <link.h>
 #include "plthook.h"
 
-#if defined __UCLIBC__ && !defined RTLD_NOLOAD
+#if (defined __UCLIBC__ || defined __HAIKU__) && !defined RTLD_NOLOAD
 #define RTLD_NOLOAD 0
 #endif
 
@@ -276,7 +279,7 @@ static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
 
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __HAIKU__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 struct dl_iterate_data {
     char* addr;
     struct link_map lmap;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -331,37 +331,53 @@ static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *c
 #endif
 
 #if defined __HAIKU__
-static int dl_iterate_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_data)
+static const char *haiku_basename(const char *path)
 {
-    struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
-    Elf_Half idx;
-    size_t load_bias = 0;
+    const char *slash = strrchr(path, '/');
+    return slash != NULL ? slash + 1 : path;
+}
 
-    (void)size;
+static int fill_link_map_haiku(struct dl_phdr_info *info, struct link_map *lmap)
+{
+    Elf_Half idx;
+    uintptr_t load_bias = (uintptr_t)info->dlpi_addr;
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
         if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
-            load_bias = (size_t)info->dlpi_addr - phdr->p_vaddr;
+            load_bias = (uintptr_t)info->dlpi_addr - phdr->p_vaddr;
             break;
         }
     }
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        char *base = (char*)(load_bias + phdr->p_vaddr);
-        if (base <= data->addr && data->addr < base + phdr->p_memsz)
-            break;
+        if (phdr->p_type == PT_DYNAMIC) {
+            lmap->l_addr = load_bias;
+            lmap->l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
+            return 1;
+        }
     }
 
-    if (idx == info->dlpi_phnum)
+    return 0;
+}
+
+static int dl_iterate_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_data)
+{
+    struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
+    Elf_Half idx;
+    struct link_map lmap;
+
+    (void)size;
+
+    if (!fill_link_map_haiku(info, &lmap))
         return 0;
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        if (phdr->p_type == PT_DYNAMIC) {
-            data->lmap.l_addr = load_bias;
-            data->lmap.l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
+        char *base = (char*)(lmap.l_addr + phdr->p_vaddr);
+        if (base <= data->addr && data->addr < base + phdr->p_memsz) {
+            data->lmap = lmap;
             return 1;
         }
     }
@@ -377,41 +393,17 @@ struct dl_iterate_name_data {
 static int dl_iterate_name_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
     struct dl_iterate_name_data *data = (struct dl_iterate_name_data*)cb_data;
-    const char *dlpi_name = info->dlpi_name;
-    const char *slash;
-    Elf_Half idx;
-    size_t load_bias = 0;
+    const char *name = info->dlpi_name;
 
     (void)size;
 
-    if (dlpi_name == NULL || dlpi_name[0] == '\0')
+    if (name == NULL || name[0] == '\0')
         return 0;
 
-    slash = strrchr(dlpi_name, '/');
-    if (slash != NULL)
-        dlpi_name = slash + 1;
-
-    if (strcmp(dlpi_name, data->name) != 0)
+    if (strcmp(haiku_basename(name), data->name) != 0)
         return 0;
 
-    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
-        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
-            load_bias = (size_t)info->dlpi_addr - phdr->p_vaddr;
-            break;
-        }
-    }
-
-    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
-        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        if (phdr->p_type == PT_DYNAMIC) {
-            data->lmap.l_addr = load_bias;
-            data->lmap.l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
-            return 1;
-        }
-    }
-
-    return 0;
+    return fill_link_map_haiku(info, &data->lmap);
 }
 
 struct dl_iterate_handle_data_haiku {
@@ -423,8 +415,6 @@ static int dl_iterate_handle_cb_haiku(struct dl_phdr_info *info, size_t size, vo
 {
     struct dl_iterate_handle_data_haiku *data = (struct dl_iterate_handle_data_haiku*)cb_data;
     void *test_handle;
-    Elf_Half idx;
-    size_t load_bias = 0;
 
     (void)size;
 
@@ -441,24 +431,7 @@ static int dl_iterate_handle_cb_haiku(struct dl_phdr_info *info, size_t size, vo
     }
     dlclose(test_handle);
 
-    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
-        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
-            load_bias = (size_t)info->dlpi_addr - phdr->p_vaddr;
-            break;
-        }
-    }
-
-    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
-        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        if (phdr->p_type == PT_DYNAMIC) {
-            data->lmap.l_addr = load_bias;
-            data->lmap.l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
-            return 1;
-        }
-    }
-
-    return 0;
+    return fill_link_map_haiku(info, &data->lmap);
 }
 #endif
 
@@ -663,32 +636,30 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
 #elif defined __HAIKU__
-    {
-        struct dl_iterate_handle_data_haiku handle_data = {0,};
-        void *executable_handle;
+    struct dl_iterate_handle_data_haiku handle_data = {0,};
+    void *executable_handle;
 
-        if (hndl == NULL) {
-            set_errmsg("NULL handle");
-            return PLTHOOK_FILE_NOT_FOUND;
-        }
-
-        executable_handle = dlopen(NULL, RTLD_LAZY);
-        if (executable_handle != NULL) {
-            if (hndl == executable_handle) {
-                dlclose(executable_handle);
-                return plthook_open_executable(plthook_out);
-            }
-            dlclose(executable_handle);
-        }
-
-        handle_data.target_handle = hndl;
-        dl_iterate_phdr(dl_iterate_handle_cb_haiku, &handle_data);
-        if (handle_data.lmap.l_ld == NULL) {
-            set_errmsg("Could not find library for the specified handle.");
-            return PLTHOOK_INTERNAL_ERROR;
-        }
-        return plthook_open_real(plthook_out, &handle_data.lmap);
+    if (hndl == NULL) {
+        set_errmsg("NULL handle");
+        return PLTHOOK_FILE_NOT_FOUND;
     }
+
+    executable_handle = dlopen(NULL, RTLD_LAZY);
+    if (executable_handle != NULL) {
+        if (hndl == executable_handle) {
+            dlclose(executable_handle);
+            return plthook_open_executable(plthook_out);
+        }
+        dlclose(executable_handle);
+    }
+
+    handle_data.target_handle = hndl;
+    dl_iterate_phdr(dl_iterate_handle_cb_haiku, &handle_data);
+    if (handle_data.lmap.l_ld == NULL) {
+        set_errmsg("Could not find library for the specified handle.");
+        return PLTHOOK_INTERNAL_ERROR;
+    }
+    return plthook_open_real(plthook_out, &handle_data.lmap);
 #elif defined __UCLIBC__ || defined __OpenBSD__
     static const char *symbols[] = {
         "__INIT_ARRAY__",
@@ -826,17 +797,16 @@ static int plthook_open_executable(plthook_t **plthook_out)
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
 #elif defined __HAIKU__
-    {
-        static int dummy;
-        struct dl_iterate_data data = {0,};
-        data.addr = (char*)&dummy;
-        dl_iterate_phdr(dl_iterate_cb_haiku, &data);
-        if (data.lmap.l_ld == NULL) {
-            set_errmsg("Could not find executable via dl_iterate_phdr");
-            return PLTHOOK_INTERNAL_ERROR;
-        }
-        return plthook_open_real(plthook_out, &data.lmap);
+    static int dummy;
+    struct dl_iterate_data data = {0,};
+
+    data.addr = (char*)&dummy;
+    dl_iterate_phdr(dl_iterate_cb_haiku, &data);
+    if (data.lmap.l_ld == NULL) {
+        set_errmsg("Could not find executable via dl_iterate_phdr");
+        return PLTHOOK_INTERNAL_ERROR;
     }
+    return plthook_open_real(plthook_out, &data.lmap);
 #elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
     return plthook_open_shared_library(plthook_out, NULL);
 #endif
@@ -846,14 +816,12 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
 {
 #if defined __HAIKU__
     struct dl_iterate_name_data name_data = {0,};
-    const char *slash;
 
     if (filename == NULL) {
         set_errmsg("NULL filename");
         return PLTHOOK_FILE_NOT_FOUND;
     }
-    slash = strrchr(filename, '/');
-    name_data.name = (slash != NULL) ? slash + 1 : filename;
+    name_data.name = haiku_basename(filename);
     dl_iterate_phdr(dl_iterate_name_cb_haiku, &name_data);
     if (name_data.lmap.l_ld == NULL) {
         set_errmsg("Could not find library '%s' via dl_iterate_phdr", filename);
@@ -1249,16 +1217,14 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
     }
 #elif defined __HAIKU__
-    {
-        const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
-        int rv_ = check_elf_header(ehdr);
-        if (rv_ != 0) {
-            return rv_;
-        }
-        if (ehdr->e_type == ET_DYN) {
-            dyn_addr_base = (uintptr_t)lmap->l_addr;
-            plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
-        }
+    const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
+    int rv_ = check_elf_header(ehdr);
+    if (rv_ != 0) {
+        return rv_;
+    }
+    if (ehdr->e_type == ET_DYN) {
+        dyn_addr_base = (uintptr_t)lmap->l_addr;
+        plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
     }
 #else
 #error unsupported OS

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -327,6 +327,46 @@ static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *c
 }
 #endif
 
+#if defined __HAIKU__
+static int dl_iterate_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_data)
+{
+    struct dl_iterate_data *data = (struct dl_iterate_data*)cb_data;
+    Elf_Half idx;
+    size_t load_bias = 0;
+
+    (void)size;
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
+            load_bias = (size_t)info->dlpi_addr - phdr->p_vaddr;
+            break;
+        }
+    }
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        char *base = (char*)(load_bias + phdr->p_vaddr);
+        if (base <= data->addr && data->addr < base + phdr->p_memsz)
+            break;
+    }
+
+    if (idx == info->dlpi_phnum)
+        return 0;
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        if (phdr->p_type == PT_DYNAMIC) {
+            data->lmap.l_addr = load_bias;
+            data->lmap.l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+#endif
+
 #if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 static int dl_iterate_cb_bsd(struct dl_phdr_info *info, size_t size, void *cb_data)
 {
@@ -575,6 +615,15 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
         return PLTHOOK_INTERNAL_ERROR;
     }
 
+    return plthook_open_real(plthook_out, &data.lmap);
+#elif defined __HAIKU__
+    struct dl_iterate_data data = {0,};
+    data.addr = address;
+    dl_iterate_phdr(dl_iterate_cb_haiku, &data);
+    if (data.lmap.l_ld == NULL) {
+        set_errmsg("Could not find memory region containing address %p", address);
+        return PLTHOOK_INTERNAL_ERROR;
+    }
     return plthook_open_real(plthook_out, &data.lmap);
 #elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
     struct dl_iterate_data data = {0,};

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -612,7 +612,7 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
     }
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
-#elif defined __UCLIBC__ || defined __OpenBSD__
+#elif defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
     static const char *symbols[] = {
         "__INIT_ARRAY__",
         "_end",
@@ -750,8 +750,9 @@ static int plthook_open_executable(plthook_t **plthook_out)
     return plthook_open_real(plthook_out, r_debug->r_map);
 #elif defined __HAIKU__
     {
+        static int dummy;
         struct dl_iterate_data data = {0,};
-        data.addr = (char*)&plthook_open_executable;
+        data.addr = (char*)&dummy;
         dl_iterate_phdr(dl_iterate_cb_haiku, &data);
         if (data.lmap.l_ld == NULL) {
             set_errmsg("Could not find executable via dl_iterate_phdr");

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -410,6 +410,53 @@ static int dl_iterate_name_cb_haiku(struct dl_phdr_info *info, size_t size, void
 
     return 0;
 }
+
+struct dl_iterate_handle_data_haiku {
+    void *target_handle;
+    struct link_map lmap;
+};
+
+static int dl_iterate_handle_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_data)
+{
+    struct dl_iterate_handle_data_haiku *data = (struct dl_iterate_handle_data_haiku*)cb_data;
+    void *test_handle;
+    Elf_Half idx;
+    size_t load_bias = 0;
+
+    (void)size;
+
+    if (info->dlpi_name == NULL || info->dlpi_name[0] == '\0')
+        return 0;
+
+    test_handle = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
+    if (test_handle == NULL)
+        return 0;
+
+    if (test_handle != data->target_handle) {
+        dlclose(test_handle);
+        return 0;
+    }
+    dlclose(test_handle);
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
+            load_bias = (size_t)info->dlpi_addr - phdr->p_vaddr;
+            break;
+        }
+    }
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        if (phdr->p_type == PT_DYNAMIC) {
+            data->lmap.l_addr = load_bias;
+            data->lmap.l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
+            return 1;
+        }
+    }
+
+    return 0;
+}
 #endif
 
 #if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
@@ -612,7 +659,23 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
     }
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
-#elif defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
+#elif defined __HAIKU__
+    {
+        struct dl_iterate_handle_data_haiku handle_data = {0,};
+
+        if (hndl == NULL) {
+            set_errmsg("NULL handle");
+            return PLTHOOK_FILE_NOT_FOUND;
+        }
+        handle_data.target_handle = hndl;
+        dl_iterate_phdr(dl_iterate_handle_cb_haiku, &handle_data);
+        if (handle_data.lmap.l_ld == NULL) {
+            set_errmsg("Could not find library for the specified handle.");
+            return PLTHOOK_INTERNAL_ERROR;
+        }
+        return plthook_open_real(plthook_out, &handle_data.lmap);
+    }
+#elif defined __UCLIBC__ || defined __OpenBSD__
     static const char *symbols[] = {
         "__INIT_ARRAY__",
         "_end",

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -984,6 +984,38 @@ static void mem_prot_end(mem_prot_iter_t *iter)
         fclose(iter->fp);
     }
 }
+#elif defined __HAIKU__
+struct mem_prot_iter {
+    ssize_t cookie;
+};
+
+static int mem_prot_begin(mem_prot_iter_t *iter)
+{
+    iter->cookie = 0;
+    return 0;
+}
+
+static int mem_prot_next(mem_prot_iter_t *iter, mem_prot_t *mem_prot)
+{
+    area_info info;
+    if (get_next_area_info(B_CURRENT_TEAM, &iter->cookie, &info) != B_OK)
+        return -1;
+    mem_prot->start = (size_t)info.address;
+    mem_prot->end = (size_t)info.address + info.size;
+    mem_prot->prot = 0;
+    if (info.protection & B_READ_AREA)
+        mem_prot->prot |= PROT_READ;
+    if (info.protection & B_WRITE_AREA)
+        mem_prot->prot |= PROT_WRITE;
+    if (info.protection & B_EXECUTE_AREA)
+        mem_prot->prot |= PROT_EXEC;
+    return 0;
+}
+
+static void mem_prot_end(mem_prot_iter_t *iter)
+{
+    (void)iter;
+}
 #else
 #error Unsupported platform
 #endif
@@ -1064,6 +1096,9 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         dyn_addr_base = (uintptr_t)lmap->l_addr;
         plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
     }
+#elif defined __HAIKU__
+    dyn_addr_base = (uintptr_t)lmap->l_addr;
+    plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
 #else
 #error unsupported OS
 #endif

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -527,7 +527,7 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
     }
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
-#elif defined __UCLIBC__ || defined __OpenBSD__
+#elif defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
     static const char *symbols[] = {
         "__INIT_ARRAY__",
         "_end",

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -79,7 +79,10 @@
 #include <link.h>
 #include "plthook.h"
 
-#if (defined __UCLIBC__ || defined __HAIKU__) && !defined RTLD_NOLOAD
+#if defined __HAIKU__ && !defined RTLD_NOLOAD
+#define RTLD_NOLOAD 4
+#endif
+#if defined __UCLIBC__ && !defined RTLD_NOLOAD
 #define RTLD_NOLOAD 0
 #endif
 

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -665,11 +665,22 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
 #elif defined __HAIKU__
     {
         struct dl_iterate_handle_data_haiku handle_data = {0,};
+        void *executable_handle;
 
         if (hndl == NULL) {
             set_errmsg("NULL handle");
             return PLTHOOK_FILE_NOT_FOUND;
         }
+
+        executable_handle = dlopen(NULL, RTLD_LAZY);
+        if (executable_handle != NULL) {
+            if (hndl == executable_handle) {
+                dlclose(executable_handle);
+                return plthook_open_executable(plthook_out);
+            }
+            dlclose(executable_handle);
+        }
+
         handle_data.target_handle = hndl;
         dl_iterate_phdr(dl_iterate_handle_cb_haiku, &handle_data);
         if (handle_data.lmap.l_ld == NULL) {

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -224,6 +224,13 @@
 #endif
 #endif /* __LP64__ */
 
+#ifdef __HAIKU__
+struct link_map {
+    uintptr_t l_addr;
+    Elf_Dyn *l_ld;
+};
+#endif
+
 #ifdef PLTHOOK_DEBUG
 #define DEBUG_MSG(...) fprintf(stderr, __VA_ARGS__)
 #else

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -70,6 +70,7 @@
 #endif
 #ifdef __HAIKU__
 #include <OS.h>
+#include <image.h>
 #endif
 #include <elf.h>
 #if defined __OpenBSD__ && (defined __aarch64__ || defined __aarch64)
@@ -636,7 +637,7 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
 #elif defined __HAIKU__
-    struct dl_iterate_handle_data_haiku handle_data = {0,};
+    struct dl_iterate_handle_data_haiku handle_data = {0};
     void *executable_handle;
 
     if (hndl == NULL) {
@@ -797,10 +798,24 @@ static int plthook_open_executable(plthook_t **plthook_out)
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
 #elif defined __HAIKU__
-    static int dummy;
     struct dl_iterate_data data = {0,};
+    image_info info;
+    int32 cookie = 0;
+    int found = 0;
 
-    data.addr = (char*)&dummy;
+    /* Anchor on the app image's base address rather than an address in
+     * plthook's own code, which may live in a shared library. */
+    while (get_next_image_info(B_CURRENT_TEAM, &cookie, &info) == B_OK) {
+        if (info.type == B_APP_IMAGE) {
+            found = 1;
+            break;
+        }
+    }
+    if (!found) {
+        set_errmsg("Could not find the application image");
+        return PLTHOOK_INTERNAL_ERROR;
+    }
+    data.addr = (char *)info.text;
     dl_iterate_phdr(dl_iterate_cb_haiku, &data);
     if (data.lmap.l_ld == NULL) {
         set_errmsg("Could not find executable via dl_iterate_phdr");

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -703,7 +703,7 @@ static int plthook_open_executable(plthook_t **plthook_out)
         return PLTHOOK_INTERNAL_ERROR;
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
-#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __HAIKU__
     return plthook_open_shared_library(plthook_out, NULL);
 #endif
 }
@@ -711,7 +711,7 @@ static int plthook_open_executable(plthook_t **plthook_out)
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
 {
     void *hndl = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
     int rv;
 #else
     struct link_map *lmap = NULL;
@@ -721,7 +721,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         set_errmsg("dlopen error: %s", dlerror());
         return PLTHOOK_FILE_NOT_FOUND;
     }
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
     rv = plthook_open_by_handle(plthook_out, hndl);
     dlclose(hndl);
     return rv;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -281,7 +281,7 @@ static void mem_prot_end(mem_prot_iter_t *iter);
 static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap);
 static int plthook_set_mem_prot(plthook_t *plthook);
 static int plthook_get_mem_prot(plthook_t *plthook, void *addr);
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __sun
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __HAIKU__ || defined __sun
 static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
@@ -1097,8 +1097,17 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
         plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
     }
 #elif defined __HAIKU__
-    dyn_addr_base = (uintptr_t)lmap->l_addr;
-    plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
+    {
+        const Elf_Ehdr *ehdr = (const Elf_Ehdr*)lmap->l_addr;
+        int rv_ = check_elf_header(ehdr);
+        if (rv_ != 0) {
+            return rv_;
+        }
+        if (ehdr->e_type == ET_DYN) {
+            dyn_addr_base = (uintptr_t)lmap->l_addr;
+            plthook.plt_addr_base = (uintptr_t)lmap->l_addr;
+        }
+    }
 #else
 #error unsupported OS
 #endif
@@ -1243,7 +1252,7 @@ static int plthook_get_mem_prot(plthook_t *plthook, void *addr)
     return 0;
 }
 
-#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __sun
+#if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __HAIKU__ || defined __sun
 static int check_elf_header(const Elf_Ehdr *ehdr)
 {
     static const unsigned short s = 1;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -332,30 +332,15 @@ static int dl_iterate_cb_android(struct dl_phdr_info *info, size_t size, void *c
 #endif
 
 #if defined __HAIKU__
-static const char *haiku_basename(const char *path)
-{
-    const char *slash = strrchr(path, '/');
-    return slash != NULL ? slash + 1 : path;
-}
-
 static int fill_link_map_haiku(struct dl_phdr_info *info, struct link_map *lmap)
 {
     Elf_Half idx;
-    uintptr_t load_bias = (uintptr_t)info->dlpi_addr;
-
-    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
-        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
-        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
-            load_bias = (uintptr_t)info->dlpi_addr - phdr->p_vaddr;
-            break;
-        }
-    }
 
     for (idx = 0; idx < info->dlpi_phnum; ++idx) {
         const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
         if (phdr->p_type == PT_DYNAMIC) {
-            lmap->l_addr = load_bias;
-            lmap->l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
+            lmap->l_addr = (uintptr_t)info->dlpi_addr;
+            lmap->l_ld = (Elf_Dyn*)((uintptr_t)info->dlpi_addr + phdr->p_vaddr);
             return 1;
         }
     }
@@ -384,27 +369,6 @@ static int dl_iterate_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_
     }
 
     return 0;
-}
-
-struct dl_iterate_name_data {
-    const char *name;
-    struct link_map lmap;
-};
-
-static int dl_iterate_name_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_data)
-{
-    struct dl_iterate_name_data *data = (struct dl_iterate_name_data*)cb_data;
-    const char *name = info->dlpi_name;
-
-    (void)size;
-
-    if (name == NULL || name[0] == '\0')
-        return 0;
-
-    if (strcmp(haiku_basename(name), data->name) != 0)
-        return 0;
-
-    return fill_link_map_haiku(info, &data->lmap);
 }
 
 struct dl_iterate_handle_data_haiku {
@@ -829,23 +793,8 @@ static int plthook_open_executable(plthook_t **plthook_out)
 
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
 {
-#if defined __HAIKU__
-    struct dl_iterate_name_data name_data = {0,};
-
-    if (filename == NULL) {
-        set_errmsg("NULL filename");
-        return PLTHOOK_FILE_NOT_FOUND;
-    }
-    name_data.name = haiku_basename(filename);
-    dl_iterate_phdr(dl_iterate_name_cb_haiku, &name_data);
-    if (name_data.lmap.l_ld == NULL) {
-        set_errmsg("Could not find library '%s' via dl_iterate_phdr", filename);
-        return PLTHOOK_FILE_NOT_FOUND;
-    }
-    return plthook_open_real(plthook_out, &name_data.lmap);
-#else
     void *hndl = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__ || defined __HAIKU__
     int rv;
 #else
     struct link_map *lmap = NULL;
@@ -855,7 +804,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         set_errmsg("dlopen error: %s", dlerror());
         return PLTHOOK_FILE_NOT_FOUND;
     }
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__ || defined __HAIKU__
     rv = plthook_open_by_handle(plthook_out, hndl);
     dlclose(hndl);
     return rv;
@@ -868,7 +817,6 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
     dlclose(hndl);
     return plthook_open_real(plthook_out, lmap);
 #endif
-#endif /* __HAIKU__ */
 }
 
 static const Elf_Dyn *find_dyn_by_tag(const Elf_Dyn *dyn, dyn_tag_t tag)

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -365,6 +365,51 @@ static int dl_iterate_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_
 
     return 0;
 }
+
+struct dl_iterate_name_data {
+    const char *name;
+    struct link_map lmap;
+};
+
+static int dl_iterate_name_cb_haiku(struct dl_phdr_info *info, size_t size, void *cb_data)
+{
+    struct dl_iterate_name_data *data = (struct dl_iterate_name_data*)cb_data;
+    const char *dlpi_name = info->dlpi_name;
+    const char *slash;
+    Elf_Half idx;
+    size_t load_bias = 0;
+
+    (void)size;
+
+    if (dlpi_name == NULL || dlpi_name[0] == '\0')
+        return 0;
+
+    slash = strrchr(dlpi_name, '/');
+    if (slash != NULL)
+        dlpi_name = slash + 1;
+
+    if (strcmp(dlpi_name, data->name) != 0)
+        return 0;
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        if (phdr->p_type == PT_LOAD && phdr->p_offset == 0) {
+            load_bias = (size_t)info->dlpi_addr - phdr->p_vaddr;
+            break;
+        }
+    }
+
+    for (idx = 0; idx < info->dlpi_phnum; ++idx) {
+        const Elf_Phdr *phdr = &info->dlpi_phdr[idx];
+        if (phdr->p_type == PT_DYNAMIC) {
+            data->lmap.l_addr = load_bias;
+            data->lmap.l_ld = (Elf_Dyn*)(load_bias + phdr->p_vaddr);
+            return 1;
+        }
+    }
+
+    return 0;
+}
 #endif
 
 #if defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
@@ -567,7 +612,7 @@ int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
     }
 
     return plthook_open_by_address(plthook_out, handle_data.base_addr);
-#elif defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
+#elif defined __UCLIBC__ || defined __OpenBSD__
     static const char *symbols[] = {
         "__INIT_ARRAY__",
         "_end",
@@ -703,15 +748,43 @@ static int plthook_open_executable(plthook_t **plthook_out)
         return PLTHOOK_INTERNAL_ERROR;
     }
     return plthook_open_real(plthook_out, r_debug->r_map);
-#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __HAIKU__
+#elif defined __HAIKU__
+    {
+        struct dl_iterate_data data = {0,};
+        data.addr = (char*)&plthook_open_executable;
+        dl_iterate_phdr(dl_iterate_cb_haiku, &data);
+        if (data.lmap.l_ld == NULL) {
+            set_errmsg("Could not find executable via dl_iterate_phdr");
+            return PLTHOOK_INTERNAL_ERROR;
+        }
+        return plthook_open_real(plthook_out, &data.lmap);
+    }
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
     return plthook_open_shared_library(plthook_out, NULL);
 #endif
 }
 
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
 {
+#if defined __HAIKU__
+    struct dl_iterate_name_data name_data = {0,};
+    const char *slash;
+
+    if (filename == NULL) {
+        set_errmsg("NULL filename");
+        return PLTHOOK_FILE_NOT_FOUND;
+    }
+    slash = strrchr(filename, '/');
+    name_data.name = (slash != NULL) ? slash + 1 : filename;
+    dl_iterate_phdr(dl_iterate_name_cb_haiku, &name_data);
+    if (name_data.lmap.l_ld == NULL) {
+        set_errmsg("Could not find library '%s' via dl_iterate_phdr", filename);
+        return PLTHOOK_FILE_NOT_FOUND;
+    }
+    return plthook_open_real(plthook_out, &name_data.lmap);
+#else
     void *hndl = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
     int rv;
 #else
     struct link_map *lmap = NULL;
@@ -721,7 +794,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         set_errmsg("dlopen error: %s", dlerror());
         return PLTHOOK_FILE_NOT_FOUND;
     }
-#if defined __ANDROID__ || defined __UCLIBC__ || defined __HAIKU__ || defined __OpenBSD__
+#if defined __ANDROID__ || defined __UCLIBC__ || defined __OpenBSD__
     rv = plthook_open_by_handle(plthook_out, hndl);
     dlclose(hndl);
     return rv;
@@ -734,6 +807,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
     dlclose(hndl);
     return plthook_open_real(plthook_out, lmap);
 #endif
+#endif /* __HAIKU__ */
 }
 
 static const Elf_Dyn *find_dyn_by_tag(const Elf_Dyn *dyn, dyn_tag_t tag)

--- a/test/Makefile
+++ b/test/Makefile
@@ -61,7 +61,7 @@ ifeq ($(UNAME_S),Haiku)
   TESTS = relro_pie_tests
   LIBS = -lm -lbsd
   LDFLAGS += -Wl,-rpath,.
-  LIBPATH_ENV = LIBRARY_PATH=.
+  LIBPATH_ENV =
   CFLAGS_WARNING += -Werror
 endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,7 @@ LIBS = -ldl -lm
 PLTHOOK_C = plthook_elf.c
 TESTS = run_tests
 KICK_CMD =
+LIBPATH_ENV = LD_LIBRARY_PATH=.
 
 ifeq ($(UNAME_S),Linux)
   # Linux
@@ -59,6 +60,7 @@ ifeq ($(UNAME_S),Haiku)
   # Haiku
   TESTS = relro_pie_tests
   LIBS = -lm -lbsd
+  LIBPATH_ENV = LIBRARY_PATH=.
   CFLAGS_WARNING += -Werror
 endif
 
@@ -103,9 +105,9 @@ testprog$(EXEEXT): testprog.c testlazybinding.c ../$(PLTHOOK_C) libtest.h
 	$(CC) $(CFLAGS_EXE) $(CFLAGS) -o testprog$(EXEEXT) -I.. testprog.c testlazybinding.c ../$(PLTHOOK_C) -L. -ltest $(LIBS) $(LDFLAGS)
 
 run_tests: clean libtest.$(SOEXT) testprog$(EXEEXT)
-	LD_LIBRARY_PATH=. $(KICK_CMD) ./testprog$(EXEEXT) open
-	LD_LIBRARY_PATH=. $(KICK_CMD) ./testprog$(EXEEXT) open_by_handle
-	test "$(SKIP_OPEN_BY_ADDRESS_TEST)" || env LD_LIBRARY_PATH=. $(KICK_CMD) ./testprog$(EXEEXT) open_by_address
+	$(LIBPATH_ENV) $(KICK_CMD) ./testprog$(EXEEXT) open
+	$(LIBPATH_ENV) $(KICK_CMD) ./testprog$(EXEEXT) open_by_handle
+	test "$(SKIP_OPEN_BY_ADDRESS_TEST)" || env $(LIBPATH_ENV) $(KICK_CMD) ./testprog$(EXEEXT) open_by_address
 
 check: $(TESTS)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -55,6 +55,13 @@ ifeq ($(UNAME_S),OpenBSD)
   CFLAGS_WARNING += -Werror
 endif
 
+ifeq ($(UNAME_S),Haiku)
+  # Haiku
+  TESTS = relro_pie_tests
+  LIBS = -lm
+  CFLAGS_WARNING += -Werror
+endif
+
 ifneq (,$(findstring MINGW,$(UNAME_S)))
   # Mingw
   CFLAGS_SHARED = -shared

--- a/test/Makefile
+++ b/test/Makefile
@@ -58,7 +58,7 @@ endif
 ifeq ($(UNAME_S),Haiku)
   # Haiku
   TESTS = relro_pie_tests
-  LIBS = -ldl -lm
+  LIBS = -lm -lbsd
   CFLAGS_WARNING += -Werror
 endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -58,7 +58,7 @@ endif
 ifeq ($(UNAME_S),Haiku)
   # Haiku
   TESTS = relro_pie_tests
-  LIBS = -lm
+  LIBS = -ldl -lm
   CFLAGS_WARNING += -Werror
 endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,6 +60,7 @@ ifeq ($(UNAME_S),Haiku)
   # Haiku
   TESTS = relro_pie_tests
   LIBS = -lm -lbsd
+  LDFLAGS += -Wl,-rpath,.
   LIBPATH_ENV = LIBRARY_PATH=.
   CFLAGS_WARNING += -Werror
 endif

--- a/test/android/run_tests.sh
+++ b/test/android/run_tests.sh
@@ -21,6 +21,9 @@ ABI=x86_64
 
 adb root || true
 adb wait-for-device
+adb logcat -c
+adb logcat > /tmp/android_logcat.txt &
+LOGCAT_PID=$!
 
 adb push "libs/$ABI/libtest.so" /data/local/tmp/
 adb push "libs/$ABI/testprog"   /data/local/tmp/
@@ -31,3 +34,6 @@ run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_
 run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_handle"
 
 echo "All Android tests passed!"
+kill $LOGCAT_PID || true
+echo "=== Logcat output ==="
+cat /tmp/android_logcat.txt

--- a/test/android/run_tests.sh
+++ b/test/android/run_tests.sh
@@ -21,9 +21,6 @@ ABI=x86_64
 
 adb root || true
 adb wait-for-device
-adb logcat -c
-adb logcat > /tmp/android_logcat.txt &
-LOGCAT_PID=$!
 
 adb push "libs/$ABI/libtest.so" /data/local/tmp/
 adb push "libs/$ABI/testprog"   /data/local/tmp/
@@ -34,6 +31,3 @@ run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_
 run_on_device "LD_LIBRARY_PATH=/data/local/tmp /data/local/tmp/testprog open_by_handle"
 
 echo "All Android tests passed!"
-kill $LOGCAT_PID || true
-echo "=== Logcat output ==="
-cat /tmp/android_logcat.txt

--- a/test/testprog.c
+++ b/test/testprog.c
@@ -286,6 +286,9 @@ static void hook_function_calls_in_library(enum open_mode open_mode)
 #if defined(_WIN32)
         handle = GetModuleHandle(filename);
 #else
+#if defined(__HAIKU__) && !defined(RTLD_NOLOAD)
+#define RTLD_NOLOAD 0
+#endif
         handle = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
 #endif
         assert(handle != NULL);

--- a/test/testprog.c
+++ b/test/testprog.c
@@ -287,7 +287,7 @@ static void hook_function_calls_in_library(enum open_mode open_mode)
         handle = GetModuleHandle(filename);
 #else
 #if defined(__HAIKU__) && !defined(RTLD_NOLOAD)
-#define RTLD_NOLOAD 0
+#define RTLD_NOLOAD 4
 #endif
         handle = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
 #endif


### PR DESCRIPTION
## Summary

Adds support for the Haiku operating system to plthook.

Haiku uses an ELF-based runtime loader but does not expose the glibc/BSD
mechanisms plthook relies on (`_r_debug`, `dlinfo`, `RTLD_DI_LINKMAP`,
`dladdr1`). This PR adds a Haiku code path built on top of `dl_iterate_phdr`
plus Haiku's `image.h` API.

### Core (`plthook_elf.c`)

* New `dl_iterate_phdr`-based callbacks for resolving images by address and
  by name (`dl_iterate_cb_haiku`, `dl_iterate_name_cb_haiku`, and the
  `plthook_open_by_handle` helper).
  `get_next_image_info(B_CURRENT_TEAM, ...)` for the `B_APP_IMAGE` entry and
  uses its text base, rather than the address of plthook's own code. This
  keeps things correct when plthook is built into a shared library instead of
  the executable.
* Memory-protection lookups and assorted C89/portability adjustments for the
  Haiku toolchain.

## Testing

Test suite (`open`, `open_by_handle`, `open_by_address`) passes on Haiku
r1beta5 via the new CI workflow.
